### PR TITLE
Support null keys and values in map, set and bag.

### DIFF
--- a/src/main/java/org/pcollections/MapPBag.java
+++ b/src/main/java/org/pcollections/MapPBag.java
@@ -72,7 +72,7 @@ public final class MapPBag<E> extends AbstractCollection<E> implements PBag<E> {
 	public int hashCode() {
 		int hashCode = 0;
 		for(E e : this)
-			hashCode += e.hashCode();
+			hashCode += Objects.hashCode(e);
 		return hashCode;
 	}
 	

--- a/src/main/java/org/pcollections/Objects.java
+++ b/src/main/java/org/pcollections/Objects.java
@@ -1,0 +1,38 @@
+package org.pcollections;
+
+/**
+ * Utility methods for operating on objects from Java 1.7.
+ */
+class Objects {
+    /**
+     * Returns {@code true} if the arguments are equal to each other
+     * and {@code false} otherwise.
+     * Consequently, if both arguments are {@code null}, {@code true}
+     * is returned and if exactly one argument is {@code null}, {@code
+     * false} is returned.  Otherwise, equality is determined by using
+     * the {@link Object#equals equals} method of the first
+     * argument.
+     *
+     * @param a an object
+     * @param b an object to be compared with {@code a} for equality
+     * @return {@code true} if the arguments are equal to each other
+     * and {@code false} otherwise
+     * @see Object#equals(Object)
+     */
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+
+    /**
+     * Returns the hash code of a non-{@code null} argument and 0 for
+     * a {@code null} argument.
+     *
+     * @param o an object
+     * @return the hash code of a non-{@code null} argument and 0 for
+     * a {@code null} argument
+     * @see Object#hashCode
+     */
+    public static int hashCode(Object o) {
+        return o != null ? o.hashCode() : 0;
+    }
+}

--- a/src/main/java/org/pcollections/SimpleImmutableEntry.java
+++ b/src/main/java/org/pcollections/SimpleImmutableEntry.java
@@ -103,7 +103,7 @@ import java.util.Map.Entry;
 		if (!(o instanceof Map.Entry))
 			return false;
 		Map.Entry<?,?> e = (Map.Entry<?,?>)o;
-		return eq(key, e.getKey()) && eq(value, e.getValue());
+		return Objects.equals(key, e.getKey()) && Objects.equals(value, e.getValue());
 	}
 
 	/**
@@ -138,11 +138,4 @@ import java.util.Map.Entry;
 		return key + "=" + value;
 	}
 
-    /**
-     * Utility method for SimpleEntry and SimpleImmutableEntry.
-     * Test for equality, checking for nulls.
-     */
-    private static boolean eq(Object o1, Object o2) {
-        return o1 == null ? o2 == null : o1.equals(o2);
-    }
 }

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -24,7 +24,8 @@ public class HashPMapTest extends TestCase {
 		Random r = new Random();
 		for(int i=0;i<10000;i++) {
 			if(pmap.size()==0 || r.nextBoolean()) { // add
-				int k = r.nextInt(), v = r.nextInt();
+				Integer k = r.nextInt(100) < 1 ? null : r.nextInt(),
+						v = r.nextInt(100) < 1 ? null : r.nextInt();
 
 				assertEquals(map.containsKey(k), pmap.containsKey(k));
 				assertEquals(map.get(k), pmap.get(k));
@@ -34,7 +35,7 @@ public class HashPMapTest extends TestCase {
 			} else { // remove a random key
 				int j = r.nextInt(pmap.size());
 				for(Entry<Integer,Integer> e : pmap.entrySet()) {
-					int k = e.getKey();
+					Integer k = e.getKey();
 
 					assertTrue(map.containsKey(k));
 					assertTrue(pmap.containsKey(k));

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -1,7 +1,6 @@
 package org.pcollections.tests;
 
-import java.util.Iterator;
-import java.util.Random;
+import java.util.*;
 
 import junit.framework.TestCase;
 
@@ -57,5 +56,16 @@ public class OrderedPSetTest extends TestCase {
 		}
 
 		assertEquals(s, os);
+	}
+
+	public void testAllowsNulls() {
+		POrderedSet<Long> s = Empty.orderedSet();
+		s = s.plus(1L).plus(2L).plus(null).plusAll(Arrays.asList(2L, 1L, null));
+
+		List<Long> expectedOrdered = Arrays.asList(1L, 2L, null);
+		Set<Long> expected = new LinkedHashSet<Long>(expectedOrdered);
+
+		UtilityTest.assertEqualsAndHash(expected, s);
+		UtilityTest.assertEqualsAndHash(expectedOrdered, new ArrayList<Long>(s));
 	}
 }


### PR DESCRIPTION
Support null keys in `HashPMap`, null values in map-based sets, and null values in `MapPBag`.
Fixes #36.
