### PR TITLE
Optimize HashPMap.get and other operations: do not create unnecessary iterator instances

### DIFF
--- a/src/main/java/org/pcollections/AmortizedPQueue.java
+++ b/src/main/java/org/pcollections/AmortizedPQueue.java
@@ -53,22 +53,29 @@ public class AmortizedPQueue<E> extends AbstractQueue<E> implements PQueue<E> {
 	/* Worst-case O(n) */
 	@Override
 	public Iterator<E> iterator() {
-		return new Iterator<E>() {
-			private PQueue<E> queue = AmortizedPQueue.this;
-			public boolean hasNext() {
-				return queue.size() > 0;
-			}
+		return new Itr<E>(this);
+	}
 
-			public E next() {
-				E e = queue.peek();
-				queue = queue.minus();
-				return e;
-			}
+	private static class Itr<E> implements Iterator<E> {
+		private AmortizedPQueue<E> queue;
 
-			public void remove() {
-				throw new UnsupportedOperationException();
-			}
-		};
+		Itr(AmortizedPQueue<E> queue) {
+			this.queue = queue;
+		}
+
+		public boolean hasNext() {
+			return queue.size() > 0;
+		}
+
+		public E next() {
+			E e = queue.peek();
+			queue = queue.minus();
+			return e;
+		}
+
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
 	}
 
 	/* Worst-case O(1) */

--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -60,7 +60,7 @@ public final class ConsPStack<E> extends AbstractSequentialList<E> implements PS
 
 	
 //// PRIVATE CONSTRUCTORS ////
-	private final E first; private final ConsPStack<E> rest;
+	final E first; final ConsPStack<E> rest;
 	private final int size;
 	// not externally instantiable (or subclassable):
 	private ConsPStack() { // EMPTY constructor

--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -84,38 +84,46 @@ public final class ConsPStack<E> extends AbstractSequentialList<E> implements PS
 	public ListIterator<E> listIterator(final int index) {
 		if(index<0 || index>size) throw new IndexOutOfBoundsException();
 		
-		return new ListIterator<E>() {
-			int i = index;
-			ConsPStack<E> next = subList(index);
-
-			public boolean hasNext() {
-				return next.size>0; }
-			public boolean hasPrevious() {
-				return i>0; }
-			public int nextIndex() {
-				return index; }
-			public int previousIndex() {
-				return index-1; }
-			public E next() {
-				E e = next.first;
-				next = next.rest;
-				return e;
-			}
-			public E previous() {
-				System.err.println("ConsPStack.listIterator().previous() is inefficient, don't use it!");
-				next = subList(index-1); // go from beginning...
-				return next.first;
-			}
-
-			public void add(final E o) {
-				throw new UnsupportedOperationException(); }
-			public void remove() {
-				throw new UnsupportedOperationException(); }
-			public void set(final E o) {
-				throw new UnsupportedOperationException(); }
-		};
+		return new Itr(index);
 	}
 
+	private class Itr implements ListIterator<E> {
+		private final int index;
+		int i;
+		ConsPStack<E> next;
+
+		Itr(int index) {
+			this.index = index;
+			i = index;
+			next = subList(index);
+		}
+
+		public boolean hasNext() {
+			return next.size>0; }
+		public boolean hasPrevious() {
+			return i>0; }
+		public int nextIndex() {
+			return index; }
+		public int previousIndex() {
+			return index -1; }
+		public E next() {
+			E e = next.first;
+			next = next.rest;
+			return e;
+		}
+		public E previous() {
+			System.err.println("ConsPStack.listIterator().previous() is inefficient, don't use it!");
+			next = subList(index -1); // go from beginning...
+			return next.first;
+		}
+
+		public void add(final E o) {
+			throw new UnsupportedOperationException(); }
+		public void remove() {
+			throw new UnsupportedOperationException(); }
+		public void set(final E o) {
+			throw new UnsupportedOperationException(); }
+	}
 
 //// OVERRIDDEN METHODS FROM AbstractSequentialList ////
 	@Override

--- a/src/main/java/org/pcollections/HashPMap.java
+++ b/src/main/java/org/pcollections/HashPMap.java
@@ -35,15 +35,16 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	 * @return a map backed by an empty version of intMap,
 	 * 	i.e. backed by intMap.minusAll(intMap.keySet())
 	 */
+	@SuppressWarnings("unchecked")
 	public static <K,V> HashPMap<K,V> empty(final PMap<Integer,PSequence<Entry<K,V>>> intMap) {
-		return new HashPMap<K,V>(intMap.minusAll(intMap.keySet()), 0); }
+		return new HashPMap<K,V>((PMap) intMap.minusAll(intMap.keySet()), 0); }
 	
 
 //// PRIVATE CONSTRUCTORS ////
-	private final PMap<Integer,PSequence<Entry<K,V>>> intMap;
+	private final PMap<Integer,ConsPStack<Entry<K,V>>> intMap;
 	private final int size;
 	// not externally instantiable (or subclassable):
-	private HashPMap(final PMap<Integer,PSequence<Entry<K,V>>> intMap, final int size) {
+	private HashPMap(final PMap<Integer,ConsPStack<Entry<K,V>>> intMap, final int size) {
 		this.intMap = intMap; this.size = size; }
 
 	
@@ -109,7 +110,7 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	}
 	
 	public HashPMap<K,V> plus(final K key, final V value) {
-		PSequence<Entry<K,V>> entries = getEntries(key.hashCode());
+		ConsPStack<Entry<K,V>> entries = getEntries(key.hashCode());
 		int size0 = entries.size(),
 			i = keyIndexIn(entries, key);
 		if(i!=-1) entries = entries.minus(i);
@@ -119,7 +120,7 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	}
 
 	public HashPMap<K,V> minus(final Object key) {
-		PSequence<Entry<K,V>> entries = getEntries(key.hashCode());
+		ConsPStack<Entry<K,V>> entries = getEntries(key.hashCode());
 		int i = keyIndexIn(entries, key);
 		if(i==-1) // key not in this
 			return this;
@@ -134,8 +135,8 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	
 	
 //// PRIVATE UTILITIES ////
-	private PSequence<Entry<K,V>> getEntries(final int hash) {
-		PSequence<Entry<K,V>> entries = intMap.get(hash);
+	private ConsPStack<Entry<K,V>> getEntries(final int hash) {
+		ConsPStack<Entry<K,V>> entries = intMap.get(hash);
 		if(entries==null) return ConsPStack.empty();
 		return entries;
 	}
@@ -152,10 +153,10 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 		return -1;
 	}
 	
-	static class SequenceIterator<E> implements Iterator<E> {
-		private final Iterator<PSequence<E>> i;
+	private static class SequenceIterator<E> implements Iterator<E> {
+		private final Iterator<ConsPStack<E>> i;
 		private PSequence<E> seq = ConsPStack.empty();
-		SequenceIterator(Iterator<PSequence<E>> i) {
+		SequenceIterator(Iterator<ConsPStack<E>> i) {
 			this.i = i; }
 
 		public boolean hasNext() {

--- a/src/main/java/org/pcollections/HashPMap.java
+++ b/src/main/java/org/pcollections/HashPMap.java
@@ -54,27 +54,28 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	@Override
 	public Set<Entry<K,V>> entrySet() {
 		if(entrySet==null)
-			entrySet = new AbstractSet<Entry<K,V>>() {
-				// REQUIRED METHODS OF AbstractSet // 
-				@Override
-				public int size() {
-					return size; }		
-				@Override
-				public Iterator<Entry<K,V>> iterator() {
-					return new SequenceIterator<Entry<K,V>>(intMap.values().iterator()); }
-				// OVERRIDDEN METHODS OF AbstractSet //
-				@Override
-				public boolean contains(final Object e) {
-					if(!(e instanceof Entry))
-						return false;
-					V value = get(((Entry<?,?>)e).getKey());
-					return value!=null && value.equals(((Entry<?,?>)e).getValue());
-				}
-			};
+			entrySet = new EntrySet();
 		return entrySet;
 	}
 
-	
+	private class EntrySet extends AbstractSet<Entry<K,V>> {
+		// REQUIRED METHODS OF AbstractSet //
+		@Override
+		public int size() {
+			return size; }
+		@Override
+		public Iterator<Entry<K,V>> iterator() {
+			return new SequenceIterator<Entry<K,V>>(intMap.values().iterator()); }
+		// OVERRIDDEN METHODS OF AbstractSet //
+		@Override
+		public boolean contains(final Object e) {
+			if(!(e instanceof Map.Entry))
+				return false;
+			V value = get(((Entry<?,?>)e).getKey());
+			return value!=null && value.equals(((Entry<?,?>)e).getValue());
+		}
+	}
+
 //// OVERRIDDEN METHODS FROM AbstractMap ////
 	@Override
 	public int size() {

--- a/src/main/java/org/pcollections/HashPMap.java
+++ b/src/main/java/org/pcollections/HashPMap.java
@@ -86,10 +86,13 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 	
 	@Override
 	public V get(final Object key) {
-		PSequence<Entry<K,V>> entries = getEntries(key.hashCode());
-		for(Entry<K,V> entry : entries)
-			if(entry.getKey().equals(key))
+		ConsPStack<Entry<K,V>> entries = getEntries(key.hashCode());
+		while(entries != null && !entries.isEmpty()) {
+			Entry<K,V> entry = entries.first;
+			if (entry.getKey().equals(key))
 				return entry.getValue();
+			entries = entries.rest;
+		}
 		return null;
 	}
 
@@ -143,9 +146,10 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 
 	
 //// PRIVATE STATIC UTILITIES ////
-	private static <K,V> int keyIndexIn(final PSequence<Entry<K,V>> entries, final Object key) {
+	private static <K,V> int keyIndexIn(final ConsPStack<Entry<K,V>> entries, final Object key) {
 		int i=0;
-		for(Entry<K,V> entry : entries) {
+		while(entries != null && !entries.isEmpty()) {
+			Entry<K,V> entry = entries.first;
 			if(entry.getKey().equals(key))
 				return i;
 			i++;

--- a/src/main/java/org/pcollections/HashPMap.java
+++ b/src/main/java/org/pcollections/HashPMap.java
@@ -147,12 +147,13 @@ public final class HashPMap<K,V> extends AbstractMap<K,V> implements PMap<K,V> {
 
 	
 //// PRIVATE STATIC UTILITIES ////
-	private static <K,V> int keyIndexIn(final ConsPStack<Entry<K,V>> entries, final Object key) {
+	private static <K,V> int keyIndexIn(ConsPStack<Entry<K,V>> entries, final Object key) {
 		int i=0;
 		while(entries != null && !entries.isEmpty()) {
 			Entry<K,V> entry = entries.first;
 			if(entry.getKey().equals(key))
 				return i;
+			entries = entries.rest;
 			i++;
 		}
 		return -1;

--- a/src/main/java/org/pcollections/IntTreePMap.java
+++ b/src/main/java/org/pcollections/IntTreePMap.java
@@ -97,27 +97,28 @@ public final class IntTreePMap<V> extends AbstractMap<Integer,V> implements PMap
 	@Override
 	public Set<Entry<Integer,V>> entrySet() {
 		if(entrySet==null)
-			entrySet = new AbstractSet<Entry<Integer,V>>() {
-				// REQUIRED METHODS OF AbstractSet // 
-				@Override
-				public int size() { // same as Map
-					return IntTreePMap.this.size(); }
-				@Override
-				public Iterator<Entry<Integer,V>> iterator() {
-					return root.iterator(); }
-				// OVERRIDDEN METHODS OF AbstractSet //
-				@Override
-				public boolean contains(final Object e) {
-					if(!(e instanceof Entry))
-						return false;
-					V value = get(((Entry<?,?>)e).getKey());
-					return value!=null && value.equals(((Entry<?,?>)e).getValue());
-				}
-			};
+			entrySet = new EntrySet();
 		return entrySet;
 	}
 
-	
+	private class EntrySet extends AbstractSet<Entry<Integer,V>> {
+		// REQUIRED METHODS OF AbstractSet //
+		@Override
+		public int size() { // same as Map
+			return IntTreePMap.this.size(); }
+		@Override
+		public Iterator<Entry<Integer,V>> iterator() {
+			return root.iterator(); }
+		// OVERRIDDEN METHODS OF AbstractSet //
+		@Override
+		public boolean contains(final Object e) {
+			if(!(e instanceof Map.Entry))
+				return false;
+			V value = get(((Entry<?,?>)e).getKey());
+			return value!=null && value.equals(((Entry<?,?>)e).getValue());
+		}
+	}
+
 //// OVERRIDDEN METHODS FROM AbstractMap ////
 	@Override
 	public int size() {

--- a/src/main/java/org/pcollections/MapPBag.java
+++ b/src/main/java/org/pcollections/MapPBag.java
@@ -3,6 +3,7 @@ package org.pcollections;
 import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 
 
@@ -43,25 +44,27 @@ public final class MapPBag<E> extends AbstractCollection<E> implements PBag<E> {
 		return size; }
 	@Override
 	public Iterator<E> iterator() {
-		final Iterator<Entry<E,Integer>> i = map.entrySet().iterator();
-		return new Iterator<E>() {
-			private E e; private int n=0;
-			public boolean hasNext() {
-				return n>0 || i.hasNext(); }
-			public E next() {
-				if(n==0) { // finished with current element
-					Entry<E,Integer> entry = i.next();
-					e = entry.getKey();
-					n = entry.getValue();
-				}
-				n--;
-				return e;
-			}
-			public void remove() {
-				throw new UnsupportedOperationException(); }
-		};
+		return new Itr();
 	}
-	
+
+	private class Itr implements Iterator<E> {
+		private final Iterator<Entry<E, Integer>> i = map.entrySet().iterator();
+		private E e;
+		private int n;
+		public boolean hasNext() {
+			return n>0 || i.hasNext(); }
+		public E next() {
+			if(n==0) { // finished with current element
+				Entry<E,Integer> entry = i.next();
+				e = entry.getKey();
+				n = entry.getValue();
+			}
+			n--;
+			return e;
+		}
+		public void remove() {
+			throw new UnsupportedOperationException(); }
+	}
 
 //// OVERRIDDEN METHODS OF AbstractCollection ////
 	@Override


### PR DESCRIPTION
We use PCollections as an internal cache for classes in Kotlin reflection library ([proof](https://github.com/JetBrains/kotlin/blob/master/core/reflection.jvm/src/kotlin/reflect/jvm/internal/kClassCache.kt)) and have recently found a problem: `HashPMap.get` seems to create lots of unnecessary `ConsPStack$1` objects, which are `ConsPStack` iterators, even on simple `get` access! Here's the original report (never mind my misleading answer there):
http://stackoverflow.com/questions/34214290/kotlin-massive-amounts-of-conspstack-how-can-i-avoid/34214718#34214718

This pull request optimizes iteration over `ConsPStack` inside `HashPMap`. First, I've made sure only `ConsPStack` is used as the `PSequence` implementation by making the types of parameters and fields more specific. In the second commit, I've replaced the for loop with the manual iteration over the `ConsPStack` instance. In the last commit, I've made anonymous classes inner with meaningful names, so that one will observe a more insightful `ConsPStack$Itr` in the stack trace instead of `ConsPStack$1`.
