### PR TITLE
Throw NoSuchElementException instead of NPE in next()

### DIFF
--- a/src/main/java/org/pcollections/AmortizedPQueue.java
+++ b/src/main/java/org/pcollections/AmortizedPQueue.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.AbstractQueue;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 // TODO javadoc
 // TODO tests
@@ -67,6 +68,9 @@ public class AmortizedPQueue<E> extends AbstractQueue<E> implements PQueue<E>, S
 
       public E next() {
         E e = queue.peek();
+        if (e == null && !hasNext()) {
+          throw new NoSuchElementException();
+        }
         queue = queue.minus();
         return e;
       }

--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -11,6 +11,7 @@ import java.util.AbstractSequentialList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 /**
  * A simple persistent stack of non-null values.
@@ -118,6 +119,9 @@ public final class ConsPStack<E> extends AbstractSequentialList<E>
 
       public E next() {
         E e = next.first;
+        if (e == null && !hasNext()) {
+          throw new NoSuchElementException();
+        }
         next = next.rest;
         i++;
         return e;
@@ -125,6 +129,9 @@ public final class ConsPStack<E> extends AbstractSequentialList<E>
 
       public E previous() {
         System.err.println("ConsPStack.listIterator().previous() is inefficient, don't use it!");
+        if (!hasPrevious()) {
+          throw new NoSuchElementException();
+        }
         next = subList(--i); // go from beginning...
         return next.first;
       }

--- a/src/main/java/org/pcollections/IntTree.java
+++ b/src/main/java/org/pcollections/IntTree.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 
 /**
  * A non-public utility class for persistent balanced tree maps with integer keys.
@@ -262,6 +263,10 @@ class IntTree<V> implements Serializable {
     }
 
     public Entry<Integer, V> next() {
+      if (stack.isEmpty()) {
+        throw new NoSuchElementException();
+      }
+
       IntTree<V> node = stack.get(0);
       final Entry<Integer, V> result = new SimpleImmutableEntry<Integer, V>(key, node.value);
 

--- a/src/test/java/org/pcollections/tests/ConsPStackTest.java
+++ b/src/test/java/org/pcollections/tests/ConsPStackTest.java
@@ -13,6 +13,7 @@ import java.util.ListIterator;
 import java.util.Random;
 import junit.framework.TestCase;
 import org.pcollections.ConsPStack;
+import org.pcollections.Empty;
 import org.pcollections.PStack;
 
 public class ConsPStackTest extends TestCase {
@@ -111,6 +112,11 @@ public class ConsPStackTest extends TestCase {
     assertEquals(Arrays.asList("B", "A", "B", "C"), pstack);
     assertEquals(Arrays.asList("A", "B", "C"), pstack.minus(0));
     assertEquals(Arrays.asList("B", "A", "C"), pstack.minus(2));
+  }
+
+  public void testIterator() {
+    UtilityTest.iteratorExceptions(Empty.stack().iterator());
+    UtilityTest.iteratorExceptions(Empty.stack().plus(1).iterator());
   }
 
   public void testListIterator() {

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -82,6 +82,11 @@ public class HashPMapTest extends TestCase {
     for (@SuppressWarnings("unused") Object e : empty.entrySet()) fail();
   }
 
+  public void testIterator() {
+    UtilityTest.iteratorExceptions(HashTreePMap.empty().entrySet().iterator());
+    UtilityTest.iteratorExceptions(HashTreePMap.singleton(10, "test").entrySet().iterator());
+  }
+
   public void testSingleton() {
     UtilityTest.assertEqualsAndHash(
         HashTreePMap.empty().plus(10, "test"), HashTreePMap.singleton(10, "test"));

--- a/src/test/java/org/pcollections/tests/IntTreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/IntTreePMapTest.java
@@ -82,6 +82,11 @@ public class IntTreePMapTest extends TestCase {
     for (@SuppressWarnings("unused") Object e : empty.entrySet()) fail();
   }
 
+  public void testIterator() {
+    UtilityTest.iteratorExceptions(IntTreePMap.empty().entrySet().iterator());
+    UtilityTest.iteratorExceptions(IntTreePMap.singleton(10, "test").entrySet().iterator());
+  }
+
   public void testSingleton() {
     UtilityTest.assertEqualsAndHash(
         IntTreePMap.empty().plus(10, "test"), IntTreePMap.singleton(10, "test"));

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.Random;
 import junit.framework.TestCase;
 import org.pcollections.Empty;
+import org.pcollections.OrderedPSet;
 import org.pcollections.POrderedSet;
 import org.pcollections.PSet;
 
@@ -60,5 +61,10 @@ public class OrderedPSetTest extends TestCase {
     }
 
     assertEquals(s, os);
+  }
+
+  public void testIterator() {
+    UtilityTest.iteratorExceptions(Empty.orderedSet().iterator());
+    UtilityTest.iteratorExceptions(OrderedPSet.singleton(10).iterator());
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePVectorTest.java
+++ b/src/test/java/org/pcollections/tests/TreePVectorTest.java
@@ -89,6 +89,11 @@ public class TreePVectorTest extends TestCase {
     }
   }
 
+  public void testIterator() {
+    UtilityTest.iteratorExceptions(TreePVector.empty().iterator());
+    UtilityTest.iteratorExceptions(TreePVector.singleton(10).iterator());
+  }
+
   public void testSubListStackOverflowRegression() {
     PVector<Integer> v = TreePVector.empty();
     for (int i = 0; i < 20000; i++) {

--- a/src/test/java/org/pcollections/tests/UtilityTest.java
+++ b/src/test/java/org/pcollections/tests/UtilityTest.java
@@ -8,8 +8,10 @@ package org.pcollections.tests;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.NoSuchElementException;
 import junit.framework.TestCase;
 import org.pcollections.*;
 
@@ -152,6 +154,20 @@ public class UtilityTest extends TestCase {
 
       pseq = pseq.plus(r.nextInt());
     }
+  }
+
+  static void iteratorExceptions(Iterator<?> iterator) {
+    while (iterator.hasNext()) {
+      iterator.next();
+    }
+    try {
+      iterator.next();
+    }
+    catch (NoSuchElementException e) {
+      // expected
+      return;
+    }
+    fail("Expected exception to be thrown");
   }
 
   static void assertEqualsAndHash(String s, Object a, Object b) {

--- a/src/test/java/org/pcollections/tests/UtilityTest.java
+++ b/src/test/java/org/pcollections/tests/UtilityTest.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.NoSuchElementException;
+import java.util.Random;
 import junit.framework.TestCase;
 import org.pcollections.*;
 
@@ -162,8 +162,7 @@ public class UtilityTest extends TestCase {
     }
     try {
       iterator.next();
-    }
-    catch (NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
       // expected
       return;
     }


### PR DESCRIPTION
When `Iterator.next()` is called and it has no more elements to iterate, it should throw `NoSuchElementException`. Currently that results in `NullPointerException` being thrown instead.