### PR TITLE
Fix issue #44 - JMH benchmark execution failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'me.champeau.gradle.jmh' version '0.2.0'
+    id 'me.champeau.gradle.jmh' version '0.3.1'
 }
 
 apply plugin: 'java'

--- a/src/jmh/java/org/pcollections/benchmark/Benchmarks.java
+++ b/src/jmh/java/org/pcollections/benchmark/Benchmarks.java
@@ -8,15 +8,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 
 import org.pcollections.*;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.*;
 
-import static org.pcollections.tests.Benchmarks.CollectionType.*;
-import static org.pcollections.tests.Benchmarks.BaseListType.*;
+import static org.pcollections.benchmark.Benchmarks.CollectionType.*;
+import static org.pcollections.benchmark.Benchmarks.BaseListType.*;
 
 @State(Scope.Thread)
 @Fork(2)


### PR DESCRIPTION
./gradlew jmh should no longer fail with the following error message:

C:\Users\Matei\Documents\GitHub\pcollections\src\jmh\java\org\pcollections\benchmark\Benchmarks.java:18: error: package org.pcollections.tests.Benchmarks does not exist
import static org.pcollections.tests.Benchmarks.CollectionType.\*;
                                               ^
C:\Users\Matei\Documents\GitHub\pcollections\src\jmh\java\org\pcollections\benchmark\Benchmarks.java:19: error: package org.pcollections.tests.Benchmarks does not exist
import static org.pcollections.tests.Benchmarks.BaseListType.\*;
                                               ^