### PR TITLE
Update JUnit 3.8.1 -> 5.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,13 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version:'3.8.1'
+    // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+    testCompile 'org.junit.vintage:junit-vintage-engine:5.1.0'
+    testCompile 'org.assertj:assertj-core:3.9.1'
+}
+
+test {
+    useJUnitPlatform() // Use JUnit 5
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-cor</artifactId>
+      <version>3.9.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
-      <artifactId>assertj-cor</artifactId>
+      <artifactId>assertj-core</artifactId>
       <version>3.9.1</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
+ Add AssertJ Core as a test dependency as well for fluent assertions: https://joel-costigliola.github.io/assertj/assertj-core.html

-> JUnit-vintage can run the old JUnit 3 tests without having to modify them