### PR TITLE
Lower java version to 1.6, to keep android compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ defaultTasks 'build'
 group = 'org.pcollections'
 version = '3.0.2-SNAPSHOT'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '1.6'
+targetCompatibility = '1.6'
 
 description = """PCollections"""
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
All the code in this project is still compatible with 1.6.
Lowering the compatibility levels to that version would make it compatible to Android (at least on a language level).
If this change is intentionally not wanted, just close it. Comment about the reason against it would be nice.