### PR TITLE
Only lower compatibility level for main sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,13 @@ defaultTasks 'build'
 group = 'org.pcollections'
 version = '3.0.3-SNAPSHOT'
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
+compileJava {
+    sourceCompatibility = '1.6'
+    targetCompatibility = '1.6'
+}
 
 description = """PCollections"""
 


### PR DESCRIPTION
Actually I found out a better way: Set the compatibility level of the main sources to 1.6 (you already did that) but leave the rest (tests and benchmark) untouched, so they still can use higher language level features, like lambdas.

It's not needed, to make a new release, because the main sources are already compiled with 1.6. This PR only affects tests and the benchmark.