### PR TITLE
Add native-image.properties

### DIFF
--- a/src/main/resources/META-INF/native-image/org.pcollections/pcollections/native-image.properties
+++ b/src/main/resources/META-INF/native-image/org.pcollections/pcollections/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=org.pcollections


### PR DESCRIPTION
GraalVM's [native-image](https://www.graalvm.org/docs/reference-manual/native-image/) tool can create executable self-contained applications out of jar files by doing a lot of magic, like evaluating static initializers during the compilation, making a snapshot of the memory heap, etc. However sometimes some classes' initialization need to be deferred to run-time to pass the build. This PR adds the property file that is read by the `native-image` tool during the compilation and the argumets are appended to the build tool. It's harmless for the jar itself and will be ignored by all the other tools.