### PR TITLE
Sorted maps and sets (fixes issue #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target/
 .idea
 .gradle
 *.iml
+/.classpath
+/.project
+/.settings/
+/bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
-Copyright 2008 Harold Cooper
+Copyright 2008-2011, 2014-2020, 2022 Harold Cooper, gil cattaneo, Gleb Frank,
+Günther Grill, Ilya Gorbunov, Jirka Kremser, Jochen Theodorou, Johnny Lim,
+Liam Miller, Mark Perry, Matei Dragu, Mike Klein, Oleg Osipenko, Ran Ari-Gur,
+Shantanu Kumar, and Valeriy Vyrva.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -35,12 +35,26 @@ PCollections are created using producers and static factory methods. Some exampl
 
 The same `empty()`, `singleton()`, and `from()` factory methods are found in each of the PCollections implementations, which currently include one concrete implementation for each abstract type:
 * [HashTreePMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePMap.html) provides a [PMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PMap.html) implementation, analogous to Java's HashMap.
+* [TreePMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePMap.html) provides a 
+[PSortedMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSortedMap.html) implementation, 
+analogous to Java's TreeMap.
 * [ConsPStack](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/ConsPStack.html) provides a [PStack](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PStack.html) implementation, analogous to Java's LinkedList.
 * [TreePVector](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePVector.html) provides a [PVector](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PVector.html) implementation, analogous to Java's ArrayList.
 * [HashTreePSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html) provides a [PSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSet.html) implementation, analogous to Java's HashSet.
+* [TreePSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePSet.html) provides a 
+[PSortedSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSortedSet.html) implementation, 
+analogous to Java's TreeSet.
 * [HashTreePBag](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePBag.html) provides a [PBag](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PBag.html) implementation, which is unordered like a set but can contain duplicate elements.
 
-PCollections are highly interoperable with Java Collections: every PCollection is a java.util.Collection, every PMap is a java.util.Map, every PSequence — including every PStack and PVector — is a java.util.List, and every PSet is a java.util.Set.
+PCollections are highly interoperable with Java Collections:
+
+* Every PCollection is a java.util.Collection.
+* Every PMap is a java.util.Map.
+* Every PSequence is a java.util.List.
+    * This includes every PStack and every PVector.
+* Every PSet is a java.util.Set.
+* Every PSortedMap is a java.util.SortedMap and java.util.NavigableMap.
+* Every PSortedSet is a java.util.SortedSet and java.util.NavigableSet.
 
 PCollections uses [Semantic Versioning](https://semver.org/), which establishes a strong correspondence between API changes and version numbering.
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'me.champeau.gradle.jmh'
 defaultTasks 'build'
 
 group = 'org.pcollections'
-version = '3.1.5-SNAPSHOT'
+version = '3.2.0-SNAPSHOT'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/src/main/java/org/pcollections/AbstractUnmodifiableMap.java
+++ b/src/main/java/org/pcollections/AbstractUnmodifiableMap.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A subclass of AbstractMap that overrides the various mutator methods to mark them as deprecated
+ * and unconditionally throw UnsupportedOperationException.
+ *
+ * @param <K>  the type of keys maintained by this map
+ * @param <V>  the type of mapped values
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ */
+public abstract class AbstractUnmodifiableMap<K, V> extends AbstractMap<K, V> {
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V compute(final K k, final BiFunction<? super K, ? super V, ? extends V> function) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V computeIfAbsent(final K k, final Function<? super K, ? extends V> function) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V computeIfPresent(final K k, final BiFunction<? super K, ? super V, ? extends V> function) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V merge(final K k, final V v, final BiFunction<? super V, ? super V, ? extends V> function) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V put(final K k, final V v) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public void putAll(final Map<? extends K, ? extends V> map) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V putIfAbsent(final K k, final V v) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V remove(final Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V replace(final K k, final V v) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public void replaceAll(final BiFunction<? super K, ? super V, ? extends V> function) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/org/pcollections/AbstractUnmodifiableSet.java
+++ b/src/main/java/org/pcollections/AbstractUnmodifiableSet.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+/**
+ * A subclass of AbstractSet that overrides the various mutator methods to mark them as deprecated
+ * and unconditionally throw UnsupportedOperationException.
+ *
+ * @param <E>  the type of elements maintained by this set
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ */
+public abstract class AbstractUnmodifiableSet<E> extends AbstractSet<E> {
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean add(final E e) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean addAll(final Collection<? extends E> list) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean remove(final Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean removeAll(final Collection<?> list) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean removeIf(final Predicate<? super E> filter) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException  always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public boolean retainAll(final Collection<?> list) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/org/pcollections/Empty.java
+++ b/src/main/java/org/pcollections/Empty.java
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 2008 Harold Cooper. All rights reserved.
+ * Copyright (c) 2008, 2022 Harold Cooper and Ran Ari-Gur. All rights reserved.
  * Licensed under the MIT License.
  * See LICENSE file in the project root for full license information.
  */
 
 package org.pcollections;
+
+import java.util.Comparator;
 
 /* Mike Klein, 2/27/2009 */
 
@@ -47,5 +49,21 @@ public final class Empty {
 
   public static <K, V> PMap<K, V> map() {
     return HashTreePMap.empty();
+  }
+
+  public static <E extends Comparable<? super E>> PSortedSet<E> sortedSet() {
+    return TreePSet.empty();
+  }
+
+  public static <E> PSortedSet<E> sortedSet(final Comparator<? super E> comparator) {
+    return TreePSet.empty(comparator);
+  }
+
+  public static <K extends Comparable<? super K>, V> PSortedMap<K, V> sortedMap() {
+    return TreePMap.empty();
+  }
+
+  public static <K, V> PSortedMap<K, V> sortedMap(final Comparator<? super K> comparator) {
+    return TreePMap.empty(comparator);
   }
 }

--- a/src/main/java/org/pcollections/KVTree.java
+++ b/src/main/java/org/pcollections/KVTree.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * functionality as is needed to support implementations of {@link PSortedMap} and
  * {@link PSortedSet}, namely {@link TreePMap} and {@link TreePSet}. Each instance of this class is
  * both a (sub)tree (with a host of methods for examining and manipulating that tree) and the
- * node at the root of that (sub)tree (implementing {@link Map.Entry&lt;K, V>} and providing methods
+ * node at the root of that (sub)tree (implementing {@link Map.Entry&lt;K, V&gt;} and providing methods
  * {@link #getKey()} and {@link #getValue()} to retrieve the mapping at the node). Method Javadoc
  * refers to 'this node' or 'this tree' as appropriate.</p>
  *

--- a/src/main/java/org/pcollections/KVTree.java
+++ b/src/main/java/org/pcollections/KVTree.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * <p>A persistent (immutable, purely functional) balanced-binary-tree implementation, with such
+ * functionality as is needed to support implementations of {@link PSortedMap} and
+ * {@link PSortedSet}, namely {@link TreePMap} and {@link TreePSet}. Each instance of this class is
+ * both a (sub)tree (with a host of methods for examining and manipulating that tree) and the
+ * node at the root of that (sub)tree (implementing {@link Map.Entry&lt;K, V>} and providing methods
+ * {@link #getKey()} and {@link #getValue()} to retrieve the mapping at the node). Method Javadoc
+ * refers to 'this node' or 'this tree' as appropriate.</p>
+ *
+ * <p>All operations are guaranteed to complete within O(log n) time. A complete iteration pass over
+ * entryIterator(boolean) completes in O(n) time. A few operations -- namely getKey,  getValue,
+ * isEmpty, orNullIfEmpty, and size -- complete in O(1) time.</p>
+ *
+ * @param <K>
+ *   the key type; serves as the key type for {@code TreePMap}, and as the element type for
+ *   {@code TreePSet}. This class provides various methods that maintain the ordering and
+ *   distinctness of keys based on a client-provided instance of {@code Comparator<? super K>}.
+ * @param <V>
+ *   the value type; serves as the value type for {@code TreePMap}. (Is ignored by
+ *   {@code TreePSet}.)
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ */
+/*
+ * Implementation note: this class currently implements the same balance condition as an AVL tree
+ * (namely, that the two children of a non-leaf node have heights that differ by at most one). For
+ * simplicity, the height of a node is stored explicitly in a private field (called 'height'); this
+ * allows all rebalancing to be handled by a single static method (called 'join') that effectively
+ * serves as the constructor for non-empty nodes. This is not the approach taken by Clojure and
+ * Scala -- they both use red-black trees -- but over the course of implementation, I gradually
+ * ended up at this approach; I found it to be much simpler and easier-to-verify overall, because
+ * it made for much simpler implementations of 'minus' and 'range*', and because it enabled
+ * the constructor to explicitly verify that the balance condition is always maintained.
+ */
+final class KVTree<K, V> implements Map.Entry<K, V>, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  enum SearchType {
+    LT, LE, EQ, GE, GT
+  }
+
+  /** The empty tree / leaf node. Access via {@link #empty()}. */
+  private static final KVTree<?, ?> EMPTY = new KVTree<Void, Void>();
+
+  /**
+   * The height of this tree: 0 if this tree is empty, otherwise 1 + max(left.height, right.height).
+   */
+  private final int height;
+
+  /** @return The number of mappings in this tree. */
+  private final int size;
+
+  private final KVTree<K, V> left;
+  private final K key;
+  private final V value;
+  private final KVTree<K, V> right;
+
+  /** Constructor for the empty tree / leaf node {@link #EMPTY}. */
+  private KVTree() {
+    this.height = 0;
+    this.size = 0;
+    this.left = null;
+    this.key = null;
+    this.value = null;
+    this.right = null;
+  }
+
+  /**
+   * Constructor for a non-empty/non-leaf node. Only intended to be called via {@link #join()},
+   * which takes the same parameters but also handles rebalancing if needed. (This constructor just
+   * throws an exception if 'left' and 'right' have mismatched heights.)
+   */
+  private KVTree(
+      final KVTree<K, V> left,
+      final K key,
+      final V value,
+      final KVTree<K, V> right
+  ) {
+    if (left.height + 1 < right.height || left.height > right.height + 1) {
+      // should never happen -- this is a private method -- barring a bug, could only happen if
+      // height reaches Integer.MAX_VALUE, which shouldn't be possible:
+      throw new IllegalArgumentException();
+    }
+    this.height = 1 + Math.max(left.height, right.height);
+
+    // Strictly speaking the below calculation misbehaves when size >= 2 ** 31 (in which case this
+    // wraps around to negative numbers, whereas both java.util.Collection.size() and
+    // java.util.Map.size() are documented to return Integer.MAX_VALUE); but a tree of that size
+    // would require over 100 GB of memory without even considering the size of the keys and values,
+    // so we probably don't need to support it. (Notably, the usual JDK collections don't support
+    // it, and don't even try to detect it to raise a graceful exception.)
+    this.size = left.size + 1 + right.size;
+
+    this.left = left;
+    this.key = key;
+    this.value = value;
+    this.right = right;
+  }
+
+  /**
+   * <p>Creates a tree consisting of all the mappings of 'left', in order, followed by a mapping
+   * from 'key' to 'value', followed by all the mappings of 'right', in order. Handles any necessary
+   * rebalancing if 'left' and 'right' have mismatched heights. (The intention is that this method
+   * be the only code that calls {@link #KVTree(KVTree, K, V, KVTree)} directly; all other methods
+   * should delegate to this one.)</p>
+   *
+   * <p>Requires time proportional to the difference in heights between 'left' and 'right', which is
+   * in O(log(max(left.size, right.size))) = O(log(left.size + right.size)).</p>
+   *
+   * <p>The height of the returned tree is guaranteed to be
+   * max(left.height, right.height) plus either zero or one. (This is important in ensuring the time
+   * guarantees of this method and of methods that call it.)</p>
+   *
+   * @return A tree containing the specified mappings in the specified order.
+   */
+  private static <K, V> KVTree<K, V> join(
+      final KVTree<K, V> left, final K key, final V value, final KVTree<K, V> right
+  ) {
+    final int leftHeight = left.height;
+    final int rightHeight = right.height;
+
+    if (leftHeight <= rightHeight + 1 && leftHeight + 1 >= rightHeight) {
+      return new KVTree<>(left, key, value, right);
+    } else if (leftHeight < rightHeight) {
+      if (right.height == left.height + 2 && right.left.height > right.right.height) {
+        // If we're here, then there's a height H such that:
+        //   left.height = H
+        //   right.height = H + 2
+        //     right.left.height = H + 1
+        //       right.left.left.height = either H - 1 or H
+        //       right.left.right.height = either H - 1 or H
+        //     right.right.height = H
+        // So we just need to right-rotate 'right', then combine:
+        return new KVTree<>(
+            new KVTree<>(left, key, value, right.left.left),
+            right.left.key,
+            right.left.value,
+            new KVTree<>(right.left.right, right.key, right.value, right.right));
+      } else {
+        return join(join(left, key, value, right.left), right.key, right.value, right.right);
+      }
+    } else {
+      if (left.height == right.height + 2 && left.right.height > left.left.height) {
+        // If we're here, then there's a height H such that:
+        //   left.height = H + 2
+        //     left.left.height = H
+        //     left.right.height = H + 1
+        //       left.right.left.height = either H - 1 or H
+        //       left.right.right.height = either H - 1 or H
+        //   right.height = H
+        // So we just need to left-rotate 'left', then combine:
+        return new KVTree<>(
+            new KVTree<>(left.left, left.key, left.value, left.right.left),
+            left.right.key,
+            left.right.value,
+            new KVTree<>(left.right.right, key, value, right));
+      } else {
+        return join(left.left, left.key, left.value, join(left.right, key, value, right));
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static <K, V> KVTree<K, V> empty() {
+    return (KVTree<K, V>) EMPTY;
+  }
+
+  static <K, V> KVTree<K, V> fromEntryIterator(
+      final Iterator<? extends Map.Entry<? extends K, ? extends V>> iterator
+  ) {
+    return fromIterator(iterator, IteratorType.ENTRY, Integer.MAX_VALUE);
+  }
+
+  static <K, V> KVTree<K, V> fromKeyIterator(final Iterator<? extends K> iterator) {
+    return fromIterator(iterator, IteratorType.KEY, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Whether an iterator returns entries or just keys. (This is a bit of a hack to let
+   * {@link #fromEntryIterator(Iterator)} and {@link #fromKeyIterator(Iterator)} share code. A
+   * cleaner alternative would be to wrap the key iterator in an entry iterator; but that would
+   * create lots of unnecessary Map.Entry instances.)
+   */
+  private enum IteratorType {
+    ENTRY,
+    KEY
+  }
+
+  private static <K, V> KVTree<K, V> fromIterator(
+      final Iterator<?> iterator, final IteratorType iteratorType, final int maxHeight
+  ) {
+    KVTree<K, V> curr = KVTree.empty();
+    while (true) {
+      if (curr.height >= maxHeight) {
+        assert curr.height == maxHeight;
+        return curr;
+      }
+
+      if (! iterator.hasNext()) {
+        return curr;
+      }
+
+      final KVTree<K, V> left = curr;
+
+      final Object datum = iterator.next();
+      @SuppressWarnings("unchecked")
+      final K key =
+        (K) (iteratorType == IteratorType.KEY ? datum : ((Map.Entry<?, ?>) datum).getKey());
+      @SuppressWarnings("unchecked")
+      final V value =
+        (V) (iteratorType == IteratorType.KEY ? null : ((Map.Entry<?, ?>) datum).getValue());
+
+      final KVTree<K, V> right = fromIterator(iterator, iteratorType, left.height);
+
+      curr = KVTree.join(left, key, value, right);
+
+      if (right.height < left.height) {
+        return curr;
+      }
+    }
+  }
+
+  /**
+   * Creates an iterator over the mappings in this tree.
+   *
+   * @param isLeftToRight - True if to iterate from left to right; false for right to left.
+   * @return An iterator over the mappings in this tree in the specified direction.
+   */
+  Iterator<Map.Entry<K, V>> entryIterator(final boolean isLeftToRight) {
+    return new EntryIterator<>(this, isLeftToRight);
+  }
+
+  /** Implements equals(...) as specified by Map.Entry. */
+  @Override
+  public boolean equals(final Object o) {
+    final Map.Entry<?, ?> that = o instanceof Map.Entry<?, ?> ? (Map.Entry<?, ?>) o : null;
+    return that != null
+        && Objects.equals(this.key, that.getKey())
+        && Objects.equals(this.value, that.getValue());
+  }
+
+  /** @return This node's key, or null if this node is the root of the empty tree. */
+  @Override
+  public K getKey() {
+    return this.key;
+  }
+
+  /**
+   * @return The leftmost non-empty node in this tree.
+   * @throws NoSuchElementException if this tree is empty.
+   */
+  KVTree<K, V> getLeftmost() {
+    checkNotEmpty();
+    KVTree<K, V> currNode = this;
+    while (! currNode.left.isEmpty()) {
+      currNode = currNode.left;
+    }
+    return currNode;
+  }
+
+  /**
+   * @return The rightmost non-empty node in this tree.
+   * @throws NoSuchElementException if this tree is empty.
+   */
+  KVTree<K, V> getRightmost() {
+    checkNotEmpty();
+    KVTree<K, V> currNode = this;
+    while (! currNode.right.isEmpty()) {
+      currNode = currNode.right;
+    }
+    return currNode;
+  }
+
+  /**
+   * @return
+   *   This node's value (which may be null), or null if this node is the root of the empty tree.
+   */
+  @Override
+  public V getValue() {
+    return this.value;
+  }
+
+  /** implements hashCode() as specified by Map.Entry */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(this.key)^ Objects.hashCode(this.value); 
+  }
+
+  /** @return Whether this tree contains any mappings (i.e., whether its size is 0). */
+  boolean isEmpty() {
+    return this == EMPTY;
+  }
+
+  KVTree<K, V> minus(final K key, final Comparator<? super K> comparator) {
+    if (this.isEmpty()) {
+      return this;
+    }
+
+    final int cmp = comparator.compare(key, this.key);
+    if (cmp < 0) {
+      return this.replaceLeft(this.left.minus(key, comparator));
+    } else if (cmp == 0) {
+      return concat(this.left, this.right);
+    } else {
+      return this.replaceRight(this.right.minus(key, comparator));
+    }
+  }
+
+  /**
+   * @return A tree with the same mappings as this one, minus the leftmost.
+   * @throws NoSuchElementException if this tree is empty.
+   */
+  KVTree<K, V> minusLeftmost() {
+    checkNotEmpty();
+    if (this.left.isEmpty()) {
+      return this.right;
+    }
+    return KVTree.join(this.left.minusLeftmost(), this.key, this.value, this.right);
+  }
+
+  /**
+   * @return A tree with the same mappings as this one, minus the rightmost.
+   * @throws NoSuchElementException if this tree is empty.
+   */
+  KVTree<K, V> minusRightmost() {
+    checkNotEmpty();
+    if (this.right.isEmpty()) {
+      return this.left;
+    }
+    return KVTree.join(this.left, this.key, this.value, this.right.minusRightmost());
+  }
+
+  /** @return This node, or null if this node is the root of the empty tree. */
+  Map.Entry<K, V> orNullIfEmpty() {
+    return this == EMPTY ? null : this;
+  }
+
+  KVTree<K, V> plus(final K key, final V value, final Comparator<? super K> comparator) {
+    if (this.isEmpty()) {
+      return KVTree.join(KVTree.empty(), key, value, KVTree.empty());
+    }
+
+    final int cmp = comparator.compare(key, this.key);
+    if (cmp < 0) {
+      return this.replaceLeft(this.left.plus(key, value, comparator));
+    } else if (cmp == 0) {
+      // Note: we use the *old* key, but the *new* value. For TreePSet<K>, this ensures that we
+      // don't modify the set if we already have an equivalent element. For TreePMap<K, V>, this may
+      // be a bit weird (especially when using an ordering that's not consistent with equals), but
+      // java.util.TreeMap.put(...) has the corresponding behavior, so we're in good company:
+      return this.replaceValue(value);
+    } else {
+      return this.replaceRight(this.right.plus(key, value, comparator));
+    }
+  }
+
+  KVTree<K, V> range(
+      final K leftBound,
+      final boolean isLeftBoundInclusive,
+      final K rightBound,
+      final boolean isRightBoundInclusive,
+      final Comparator<? super K> comparator
+  ) {
+    if (this.isEmpty()) {
+      return this;
+    }
+
+    final int toCmp = comparator.compare(rightBound, this.key);
+    final int fromCmp = toCmp < 0 ? -1 : comparator.compare(leftBound, this.key);
+
+    if (toCmp < 0) {
+      // if we're here, then the entire range is to the left of root
+      return this.left.range(
+          leftBound, isLeftBoundInclusive, rightBound, isRightBoundInclusive, comparator);
+    } else if (toCmp == 0) {
+      // if we're here, then the range ends at root
+      if (fromCmp == 0) {
+        // if we're here, then the range also *starts* at root
+        if (isLeftBoundInclusive && isRightBoundInclusive) {
+          return KVTree.join(KVTree.empty(), this.key, this.value, KVTree.empty());
+        } else {
+          return KVTree.empty();
+        }
+      } else {
+        final KVTree<K, V> left =
+            this.left.rangeToRight(leftBound, isLeftBoundInclusive, comparator);
+        if (isRightBoundInclusive) {
+          return KVTree.join(left, this.key, this.value, KVTree.empty());
+        } else {
+          return left;
+        }
+      }
+    } else if (fromCmp < 0) {
+      // if we're here, then the range extends on either side of root
+      return KVTree.join(
+          this.left.rangeToRight(leftBound, isLeftBoundInclusive, comparator),
+          this.key,
+          this.value,
+          this.right.rangeToLeft(rightBound, isRightBoundInclusive, comparator));
+    } else if (fromCmp == 0) {
+      // if we're here, then the range starts at root
+      final KVTree<K, V> right =
+          this.right.rangeToLeft(rightBound, isRightBoundInclusive, comparator);
+      if (isLeftBoundInclusive) {
+        return KVTree.join(KVTree.empty(), this.key, this.value, right);
+      } else {
+        return right;
+      }
+    } else {
+      // if we're here, then the entire range is to the right of root
+      return this.right.range(
+          leftBound, isLeftBoundInclusive, rightBound, isRightBoundInclusive, comparator);
+    }
+  }
+
+  KVTree<K, V> rangeToLeft(
+      final K rightBound,
+      final boolean isRightBoundInclusive,
+      final Comparator<? super K> comparator
+  ) {
+    if (this.isEmpty()) {
+      return this;
+    }
+
+    final int cmp = comparator.compare(rightBound, this.key);
+    if (cmp < 0) {
+      return this.left.rangeToLeft(rightBound, isRightBoundInclusive, comparator);
+    } else if (cmp == 0) {
+      if (isRightBoundInclusive) {
+        return KVTree.join(this.left, this.key, this.value, KVTree.empty());
+      } else {
+        return this.left;
+      }
+    } else {
+      return this.replaceRight(
+          this.right.rangeToLeft(rightBound, isRightBoundInclusive, comparator));
+    }
+  }
+
+  KVTree<K, V> rangeToRight(
+      final K leftBound,
+      final boolean isleftBoundInclusive,
+      final Comparator<? super K> comparator
+  ) {
+    if (this.isEmpty()) {
+      return this;
+    }
+
+    final int cmp = comparator.compare(leftBound, this.key);
+    if (cmp < 0) {
+      return this.replaceLeft(this.left.rangeToRight(leftBound, isleftBoundInclusive, comparator));
+    } else if (cmp == 0) {
+      if (isleftBoundInclusive) {
+        return KVTree.join(KVTree.empty(), this.key, this.value, this.right);
+      } else {
+        return this.right;
+      }
+    } else {
+      return this.right.rangeToRight(leftBound, isleftBoundInclusive, comparator);
+    }
+  }
+
+  KVTree<K, V> search(
+    final K key,
+    final Comparator<? super K> comparator,
+    final SearchType searchType
+  ) {
+    KVTree<K, V> currNode = this;
+    KVTree<K, V> candidate = KVTree.empty();
+    while (true) {
+      if (currNode.isEmpty()) {
+        return candidate;
+      }
+
+      final int cmp = comparator.compare(key, currNode.key);
+      if (cmp < 0) {
+        if (searchType == SearchType.GE || searchType == SearchType.GT) {
+          candidate = currNode;
+        }
+        currNode = currNode.left;
+      } else if (cmp == 0) {
+        if (searchType == SearchType.LT) {
+          if (currNode.left.isEmpty()) {
+            return candidate;
+          } else {
+            return currNode.left.getRightmost();
+          }
+        } else if (searchType == SearchType.LE
+            || searchType == SearchType.EQ
+            || searchType == SearchType.GE
+        ) {
+          return currNode;
+        } else {
+          if (currNode.right.isEmpty()) {
+            return candidate;
+          } else {
+            return currNode.right.getLeftmost();
+          }
+        }
+      } else {
+        if (searchType == SearchType.LT || searchType == SearchType.LE) {
+          candidate = currNode;
+        }
+        currNode = currNode.right;
+      }
+    }
+  }
+
+  /**
+   * @throws UnsupportedOperationException always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  public V setValue(final V value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /** @return The number of mappings in this tree. */
+  int size() {
+    return this.size;
+  }
+
+  /**
+   * implements toString() in a form expected for an implementation of Map.Entry, namely
+   * "KEY=VALUE" (with no information about the presence or absence of child nodes).
+   */
+  @Override
+  public String toString() {
+      return this.key + "=" + this.value;
+  }
+
+  private void checkNotEmpty() {
+    if (this.isEmpty()) {
+      throw new NoSuchElementException();
+    }
+  }
+
+  private KVTree<K, V> replaceLeft(final KVTree<K, V> newLeft) {
+    return this.left == newLeft ? this : KVTree.join(newLeft, this.key, this.value, this.right);
+  }
+
+  private KVTree<K, V> replaceRight(final KVTree<K, V> newRight) {
+    return this.right == newRight ? this : KVTree.join(this.left, this.key, this.value, newRight);
+  }
+
+  private KVTree<K, V> replaceValue(final V newValue) {
+    return this.value == newValue ? this : KVTree.join(this.left, this.key, newValue, this.right);
+  }
+
+  private static <K, V> KVTree<K, V> concat(final KVTree<K, V> left, final KVTree<K, V> right) {
+    if (right.isEmpty()) {
+      return left;
+    }
+    final KVTree<K, V> mid = right.getLeftmost();
+    final KVTree<K, V> restOfRight = right.minusLeftmost();
+    return KVTree.join(left, mid.key, mid.value, restOfRight);
+  }
+
+  /** An iterator over the mappings of a KVTree. */
+  private static class EntryIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+    /** whether we're iterating from left to right (vs. right to left) */
+    private final boolean isLeftToRight;
+
+    /** node that we need to enter */
+    private KVTree<K, V> nextSubtree; // for laziness
+
+    /** nodes that we've recursed into, but not yet returned */
+    private final ArrayList<KVTree<K, V>> stack = new ArrayList<>();
+
+    EntryIterator(final KVTree<K, V> tree, final boolean isLeftToRight) {
+      this.isLeftToRight = isLeftToRight;
+      this.nextSubtree = tree;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return this.nextSubtree.size > 0 || this.stack.size() > 0;
+    }
+
+    @Override
+    public Map.Entry<K, V> next() {
+      while (this.nextSubtree.size > 0) {
+        this.stack.add(this.nextSubtree);
+        this.nextSubtree = firstChild(this.nextSubtree);
+      }
+      if (this.stack.isEmpty()) {
+        throw new NoSuchElementException();
+      }
+      final KVTree<K, V> result = this.stack.remove(this.stack.size() - 1);
+      this.nextSubtree = secondChild(result);
+      return result;
+    }
+
+    private KVTree<K, V> firstChild(final KVTree<K, V> node) {
+      return this.isLeftToRight ? node.left : node.right;
+    }
+
+    private KVTree<K, V> secondChild(final KVTree<K, V> node) {
+      return this.isLeftToRight ? node.right : node.left;
+    }
+  }
+}

--- a/src/main/java/org/pcollections/POrderedSet.java
+++ b/src/main/java/org/pcollections/POrderedSet.java
@@ -10,7 +10,12 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 
 /**
- * Like {@link PSet} but preserves insertion order. Persistent equivalent of {@link LinkedHashSet}.
+ * <p>Like {@link PSet} but preserves insertion order. Persistent equivalent of
+ * {@link LinkedHashSet}.</p>
+ *
+ * <p>(Note: this is different from {@link PSortedSet}, which keeps elements in the order specified
+ * by {@link java.lang.Comparable#compareTo(Object)} or
+ * {@link java.util.Comparator#compare(Object, Object)}.)</p>
  *
  * @author Tassilo Horn &lt;horn@uni-koblenz.de&gt;
  * @param <E>

--- a/src/main/java/org/pcollections/PSortedMap.java
+++ b/src/main/java/org/pcollections/PSortedMap.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+
+/**
+ * <p>An immutable, persistent map from non-null keys of type K to non-null values of type V, with
+ * keys arranged in sorted order (according to some {@link java.util.Comparator}), and with various
+ * methods to obtain specific mappings or ranges of mappings based on this ordering (such as the
+ * least key greater than some instance of type K, or the sub-map with keys between two instances of
+ * type K).</p>
+ *
+ * <p>Every PSortedMap is a {@link java.util.Map} and more specifically a {@link PMap}, but as with
+ * any sorted map, a PSortedMap will only obey the general contract of those interfaces if its
+ * comparator is consistent with equals. (See {@link java.util.SortedMap} for more information.)</p>
+ *
+ * <p>Every PSortedMap is a {@link java.util.SortedMap} and more specifically a
+ * {@link java.util.NavigableMap}, but the implementations of PSortedMap provided by this library
+ * (pcollections) depart from the specification of those interfaces in a few ways:</p>
+ *
+ * <ul>
+ *   <li>headMap(...), subMap(...), and tailMap(...) are specified by SortedMap and NavigableMap to
+ *   return maps with a "restricted key range", and to throw IllegalArgumentException if this
+ *   instance already has a restricted key range and the relevant argument is outside that range.
+ *   (This ensures that map.headMap(10).headMap(15) doesn't contain elements that map.headMap(10)
+ *   does not, and that map.headMap(10).headMap(15).put(12, "x") is invalid because a mapping with
+ *   the key 12 can't be put in map.headMap(10).) This library's implementations do not throw
+ *   IllegalArgumentException, but rather, they ensure that an argument outside the applicable range
+ *   simply has no effect; so, map.headMap(10).headMap(15) is equivalent to map.headMap(10), because
+ *   map.headMap(10) already contains no elements ≥ 15. (This is also the behavior of Guava's
+ *   ImmutableSortedMap. The JDK's Collections.unmodifiableSortedMap(...) and
+ *   Collections.unmodifiableNavigableMap(...) are agnostic on this point, because they just
+ *   delegate to the underlying map.) Other implementations are encouraged to consider doing the
+ *   same, and to document their behavior in this respect. Additionally, any implementations that
+ *   <em>do</em> use the "restricted key range" concept are encouraged to document the behavior of
+ *   their minus, minusAll, plus, and plusAll methods when a key is outside the restricted key
+ *   range.</li>
+ *
+ *   <li>comparator() is specified by SortedMap to return "null if this map uses the natural
+ *   ordering of its elements". This library's implementations never return null from that method;
+ *   instead, when the map uses the natural ordering, the method returns a Comparator instance that
+ *   implements the natural ordering. (This is because this library avoids null in general; a PMap
+ *   does not allow null keys or values. This is also the behavior of Guava's ImmutableSortedMap,
+ *   which also rejects null keys and values.) Other implementations of PSortedMap are encouraged to
+ *   consider doing the same, and to document their behavior in this case (whether or not it's to
+ *   return null).</li>
+ *
+ *   <li>pollFirstEntry() and pollLastEntry() are specified by NavigableMap to mutate this map, and
+ *   are not specified to be optional operations. That's obviously not an option for a PMap, so
+ *   PSortedMap provides default implementations of these methods that simply throw
+ *   UnsupportedOperationException, which should be the right implementation for any implementation
+ *   of this interface. (This is also the behavior of the JDK's
+ *   Collections.unmodifiableNavigableMap(...) and Guava's ImmutableSortedMap.)</li>
+ * </ul>
+ *
+ * @param <K>  the type of keys maintained by this map
+ * @param <V>  the type of mapped values
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ *
+ * @see java.util.SortedMap
+ * @see java.util.NavigableMap
+ * @see java.util.Collections#unmodifiableSortedMap(java.util.SortedMap)
+ * @see java.util.Collections#unmodifiableNavigableMap(java.util.NavigableMap)
+ * @see org.pcollections.PMap
+ * @see org.pcollections.PSortedSet
+ * @see org.pcollections.TreePMap
+ */
+public interface PSortedMap<K, V> extends PMap<K, V>, NavigableMap<K, V> {
+  // methods inherited from PMap, overridden to return specifically PSortedMap:
+
+  @Override
+  public PSortedMap<K, V> plus(K key, V value);
+  @Override
+  public PSortedMap<K, V> plusAll(Map<? extends K, ? extends V> map);
+  @Override
+  public PSortedMap<K, V> minus(Object key);
+  @Override
+  public PSortedMap<K, V> minusAll(Collection<?> keys);
+
+  // methods inherited from NavigableMap, overridden to return specifically PSortedMap or
+  // PSortedSet:
+
+  @Override
+  public PSortedSet<K> descendingKeySet();
+  @Override
+  public PSortedMap<K, V> descendingMap();
+  @Override
+  public PSortedMap<K, V> headMap(K toKey);
+  @Override
+  public PSortedMap<K, V> headMap(K toKey, boolean inclusive);
+  @Override
+  public PSortedSet<K> keySet();
+  @Override
+  public PSortedSet<K> navigableKeySet();
+  @Override
+  public PSortedMap<K, V> subMap(K fromKey, K toKey);
+  @Override
+  public PSortedMap<K, V> subMap(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+  @Override
+  public PSortedMap<K, V> tailMap(K fromKey);
+  @Override
+  public PSortedMap<K, V> tailMap(K fromKey, boolean inclusive);
+
+  // other methods:
+
+  /** @return The comparator used to order the keys in this map. (Never null.) */
+  @Override
+  public Comparator<? super K> comparator();
+
+  /**
+   * @return This map, minus its first mapping (the mapping with the least/lowest key).
+   * @throws NoSuchElementException - if this map is empty
+   */
+  public PSortedMap<K, V> minusFirstEntry();
+
+  /**
+   * @return This map, minus its last mapping (the mapping with the greatest/highest key).
+   * @throws NoSuchElementException - if this map is empty
+   */
+  public PSortedMap<K, V> minusLastEntry();
+
+  /**
+   * @throws UnsupportedOperationException - always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  default Map.Entry<K, V> pollFirstEntry() {
+    throw new UnsupportedOperationException("This map instance is unmodifiable");
+  }
+
+  /**
+   * @throws UnsupportedOperationException - always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  default Map.Entry<K, V> pollLastEntry() {
+    throw new UnsupportedOperationException("This map instance is unmodifiable");
+  }
+}

--- a/src/main/java/org/pcollections/PSortedSet.java
+++ b/src/main/java/org/pcollections/PSortedSet.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+
+/**
+ * <p>An immutable, persistent set of distinct, non-null elements, with elements arranged in sorted
+ * order (according to some {@link java.util.Comparator}), and with various methods to obtain
+ * specific elements or ranges of elements based on this ordering (such as the least element greater
+ * than some value, or the set of elements between two values).</p>
+ *
+ * <p>(Note: this is different from {@link POrderedSet}, which keeps elements in the order that
+ * they were added to the set.)</p>
+ *
+ * <p>Every PSortedSet is a {@link java.util.Set} and more specifically a {@link PSet}, but as with
+ * any sorted set, a PSortedSet will only obey the general contract of those interfaces if its
+ * comparator is consistent with equals. (See {@link java.util.SortedSet} for more information.)</p>
+ *
+ * <p>Every PSortedSet is a {@link java.util.SortedSet} and more specifically a
+ * {@link java.util.NavigableSet}, but the implementations of PSortedSet provided by this library
+ * (pcollections) depart from the specification of those interfaces in a few ways:</p>
+ *
+ * <ul>
+ *   <li>headSet(...), subSet(...), and tailSet(...) are specified by SortedSet and NavigableSet to
+ *   return sets with a "restricted range", and to throw IllegalArgumentException if this instance
+ *   already has a restricted range and the relevant argument is outside that range. (This ensures
+ *   that set.headSet(10).headSet(15) doesn't contain elements that set.headSet(10) does not, and
+ *   that set.headSet(10).headSet(15).add(12) is invalid because 12 can't be added to
+ *   set.headSet(10).) This library's implementations do not throw IllegalArgumentException, but
+ *   rather, they ensure that an argument outside the applicable range simply has no effect; so,
+ *   set.headSet(10).headSet(15) is equivalent to set.headSet(10), because set.headSet(10) already
+ *   contains no elements ≥ 15. (This is also the behavior of Guava's ImmutableSortedSet. The JDK's
+ *   Collections.unmodifiableSortedSet(...) and Collections.unmodifiableNavigableSet(...) are
+ *   agnostic on this point, because they just delegate to the underlying set.) Other
+ *   implementations are encouraged to consider doing the same, and to document their behavior in
+ *   this respect. Additionally, any implementations that <em>do</em> use the "restricted range"
+ *   concept are encouraged to document the behavior of their minus, minusAll, plus, and plusAll
+ *   methods when a value is outside the restricted range.</li>
+ *
+ *   <li>comparator() is specified by SortedSet to return "null if this set uses the natural
+ *   ordering of its elements". This library's implementations never return null from that method;
+ *   instead, when the set uses the natural ordering, the method returns a Comparator instance that
+ *   implements the natural ordering. (This is because this library avoids null in general; a PSet
+ *   does not allow null elements. This is also the behavior of Guava's ImmutableSortedSet, which
+ *   also rejects null elements.) Other implementations of PSortedSet are encouraged to consider
+ *   doing the same, and to document their behavior in this case (whether or not it's to return
+ *   null).</li>
+ *
+ *   <li>pollFirst() and pollLast() are specified by NavigableSet to mutate this set, and
+ *   are not specified to be optional operations. That's obviously not an option for a PSet, so
+ *   PSortedSet provides default implementations of these methods that simply throw
+ *   UnsupportedOperationException, which should be the right implementation for any implementation
+ *   of this interface. (This is also the behavior of the JDK's
+ *   Collections.unmodifiableNavigableSet(...) and Guava's ImmutableSortedSet.)</li>
+ * </ul>
+ *
+ * @param <E>  the type of elements maintained by this set
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ *
+ * @see java.util.SortedSet
+ * @see java.util.NavigableSet
+ * @see java.util.Collections#unmodifiableSortedSet(java.util.SortedSet)
+ * @see java.util.Collections#unmodifiableNavigableSet(java.util.NavigableSet)
+ * @see org.pcollections.PSet
+ * @see org.pcollections.PSortedMap
+ * @see org.pcollections.TreePSet
+ */
+public interface PSortedSet<E> extends PSet<E>, NavigableSet<E> {
+  /**
+   * @return The comparator used to order the elements in this set. May be null if this set uses the
+   *         natural ordering of its elements, though in that case the implementations provided by
+   *         this library (pcollections) return a Comparator instance that implements the natural
+   *         ordering.
+   */
+  @Override
+  public Comparator<? super E> comparator();
+
+  @Override
+  public PSortedSet<E> descendingSet();
+
+  @Override
+  public PSortedSet<E> headSet(E toElement);
+
+  @Override
+  public PSortedSet<E> headSet(E toElement, boolean inclusive);
+
+  /**
+   * @param e
+   * @return This set, except with e removed (if e is an element of this set).
+   * @throws NullPointerException if e is null
+   * @throws ClassCastException if the type of e is incompatible with this set (optional)
+   * @throws IllegalArgumentException if e is incompatible with this set (optional)
+   */
+  @Override
+  public PSortedSet<E> minus(Object e);
+
+  /**
+   * @param list
+   * @return This set, except with the elements of list removed (if they are elements of this set).
+   * @throws NullPointerException if list is null or contains null
+   * @throws ClassCastException if list contains an element whose type is incompatible with this
+   *                            set (optional)
+   * @throws IllegalArgumentException if list contains an element that is incompatible with this
+   *                                  set (optional)
+   */
+  @Override
+  public PSortedSet<E> minusAll(Collection<?> list);
+
+  /**
+   * @return This set, except with its first (least) element removed.
+   * @throws NoSuchElementException if this set is empty
+   */
+  public PSortedSet<E> minusFirst();
+
+  /**
+   * @return This set, except with its last (greatest) element removed.
+   * @throws NoSuchElementException if this set is empty
+   */
+  public PSortedSet<E> minusLast();
+
+  /**
+   * @param e
+   * @return This set, except with e added (unless e is already an element of this set).
+   * @throws NullPointerException if e is null
+   * @throws IllegalArgumentException if e is incompatible with this set (optional)
+   */
+  @Override
+  public PSortedSet<E> plus(E e);
+
+  /**
+   * @param list
+   * @return This set, except with the elements of list added (unless they are already elements of
+   *         this set).
+   * @throws NullPointerException if list is null or contains null
+   * @throws IllegalArgumentException if list contains an element that is incompatible with this
+   *                                  set (optional)
+   */
+  @Override
+  public PSortedSet<E> plusAll(Collection<? extends E> list);
+
+  @Override
+  public PSortedSet<E> subSet(E fromElement, E toElement);
+
+  @Override
+  public PSortedSet<E> subSet(
+      E fromElement, boolean fromInclusive, E toElement, boolean toInclusive);
+
+  @Override
+  public PSortedSet<E> tailSet(E fromElement);
+
+  @Override
+  public PSortedSet<E> tailSet(E fromElement, boolean inclusive);
+
+  /**
+   * @throws UnsupportedOperationException always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  default E pollFirst() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @throws UnsupportedOperationException always
+   * @deprecated Unsupported operation.
+   */
+  @Deprecated
+  @Override
+  default E pollLast() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/org/pcollections/TreePMap.java
+++ b/src/main/java/org/pcollections/TreePMap.java
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * <p>An implementation of {@link PSortedMap} based on a self-balancing binary search tree.</p>
+ *
+ * <p>Instances of this class are obtained via any of various static factory methods and static
+ * collector methods. These methods come in pairs, with one version that accepts an explicit
+ * comparator to use and one version that uses the natural ordering of the elements.</p>
+ *
+ * <p>All operations are guaranteed to complete within O(log n) time, except for plusAll and
+ * minusAll, whose time cost is equivalent to the corresponding sequence of calls to plus or minus.
+ * A complete iteration pass over entrySet() completes in O(n) time. A few operations -- namely
+ * comparator, descendingKeySet, descendingMap, entrySet, isEmpty, keySet, navigableKeySet, and size
+ * -- complete in O(1) time.</p>
+ *
+ * @param <K>  the type of keys maintained by this map
+ * @param <V>  the type of mapped values
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ */
+public final class TreePMap<K, V> extends AbstractUnmodifiableMap<K, V>
+    implements PSortedMap<K, V>, Serializable
+{
+  private static final long serialVersionUID = 1L;
+
+  private final KVTree<K, V> tree;
+  private final Comparator<? super K> ltrComparator;
+  private final boolean isLeftToRight;
+
+  private TreePMap(
+      final KVTree<K, V> tree,
+      final Comparator<? super K> ltrComparator,
+      final boolean isLeftToRight
+  ) {
+    complainIfNull(tree, "tree is null");
+    complainIfNull(ltrComparator, "comparator is null");
+
+    this.tree = tree;
+    this.ltrComparator = ltrComparator;
+    this.isLeftToRight = isLeftToRight;
+  }
+
+  /**
+   * Returns an empty TreePMap using the natural ordering.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @return  an empty TreePMap using the natural ordering
+   */
+  public static <K extends Comparable<? super K>, V> TreePMap<K, V> empty() {
+    return empty(Comparator.naturalOrder());
+  }
+
+  /**
+   * Returns an empty TreePMap using the specified comparator.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param comparator  the comparator according to which keys should be ordered
+   * @return  an empty TreePMap using the specified comparator
+   * @throws NullPointerException  if comparator is null
+   */
+  public static <K, V> TreePMap<K, V> empty(final Comparator<? super K> comparator) {
+    return new TreePMap<>(KVTree.empty(), comparator, true);
+  }
+
+  /**
+   * Returns a TreePMap with the specified mappings, using the natural ordering of the keys.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param map  the mappings to include
+   * @return
+   *     a TreePMap containing the specified mappings and using the natural ordering of the keys
+   * @throws NullPointerException  if the map is null or contains a null key or value
+   */
+  public static <K extends Comparable<? super K>, V> TreePMap<K, V> from(
+      final Map<? extends K, ? extends V> map
+  ) {
+    return TreePMap.from(Comparator.naturalOrder(), map);
+  }
+
+  /**
+   * Returns a TreePMap with the specified comparator and mappings.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param comparator  the comparator to use
+   * @param map  the mappings to include
+   * @return  a TreePMap with the specified comparator and mappings
+   * @throws NullPointerException
+   *           if the comparator or map is null or the map contains a null key or value
+   */
+  public static <K, V> TreePMap<K, V> from(
+      final Comparator<? super K> comparator,
+      final Map<? extends K, ? extends V> map
+  ) {
+    return TreePMap.<K, V>empty(comparator).plusAll(map);
+  }
+
+  /**
+   * Returns a TreePMap with the same mappings and ordering as the specified map. This is
+   * essentially equivalent to {@code TreePMap.from(map.comparator(), map)}, except that it
+   * gracefully handles a null comparator, and is much more efficient.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param map  the map whose mappings and ordering to use
+   * @return  a TreePMap with the same mappings and ordering as the specified set
+   * @throws NullPointerException  if the specified map is null or contains a null key or value
+   */
+  public static <K, V> TreePMap<K, V> fromSortedMap(final SortedMap<K, ? extends V> map) {
+    complainIfNull(map, "map is null");
+
+    if (map instanceof TreePMap<?, ?>) {
+      return sneakilyDowncast(map);
+    }
+
+    final KVTree<K, V> tree = KVTree.fromEntryIterator(map.entrySet().iterator());
+
+    // check for null keys and values:
+    {
+      final Iterator<? extends Map.Entry<K, V>> treeIterator = tree.entryIterator(true);
+      while (treeIterator.hasNext()) {
+        final Map.Entry<K, V> entry = treeIterator.next();
+        complainIfNull(entry.getKey(), "map contains null key");
+        complainIfNull(entry.getValue(), "map contains null value");
+      }
+    }
+
+    final Comparator<? super K> thatComparator = map.comparator();
+    final Comparator<? super K> comparator =
+        thatComparator == null ? sneakilyDowncast(Comparator.naturalOrder()) : thatComparator;
+
+    return new TreePMap<K, V>(tree, comparator, true);
+  }
+
+  /**
+   * Returns a TreePMap with a single mapping, using the natural ordering of its keys.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param key  the key
+   * @param value  the value
+   * @return  a TreePMap containing the specified mapping and using the natural ordering
+   * @throws NullPointerException  if the specified key or value is null
+   */
+  public static <K extends Comparable<? super K>, V> TreePMap<K, V> singleton(
+      final K key,
+      final V value
+  ) {
+    return TreePMap.singleton(Comparator.naturalOrder(), key, value);
+  }
+
+  /**
+   * Returns a TreePMap with a single element, using the specified comparator.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param comparator  the comparator according to which keys should be ordered
+   * @param key  the key
+   * @param value  the value
+   * @return  a TreePMap containing the specified mapping and using the specified comparator
+   * @throws NullPointerException  if the specified comparator, key, or value is null
+   */
+  public static <K, V> TreePMap<K, V> singleton(
+      final Comparator<? super K> comparator,
+      final K key,
+      final V value
+  ) {
+    return TreePMap.<K, V>empty(comparator).plus(key, value);
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePMap with mappings computed from the
+   * elements of the stream (using the specified keyMapper and valueMapper), in the order determined
+   * by the natural ordering of the keys. In the event of duplicate keys, the collector will throw
+   * IllegalStateException.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param keyMapper  a function to compute the key from a stream element
+   * @param valueMapper  a function to compute the value from a stream element
+   * @return a collector that gathers the elements of the stream into a TreePMap
+   * @throws NullPointerException  if either keyMapper or valueMapper is null
+   */
+  public static <T, K extends Comparable<? super K>, V> Collector<T, ?, TreePMap<K, V>> toTreePMap(
+      final Function<? super T, ? extends K> keyMapper,
+      final Function<? super T, ? extends V> valueMapper
+  ) {
+    return toTreePMap(Comparator.naturalOrder(), keyMapper, valueMapper);
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePMap with mappings computed from the
+   * elements of the stream (using the specified keyMapper and valueMapper), in the order determined
+   * by the specified comparator. In the event of duplicate keys, the collector will throw
+   * IllegalStateException.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param comparator  the comparator according to which keys should be ordered
+   * @param keyMapper  a function to compute the key from a stream element
+   * @param valueMapper  a function to compute the value from a stream element
+   * @return a collector that gathers the elements of the stream into a TreePMap
+   * @throws NullPointerException  if any of this method's arguments are null
+   */
+  public static <T, K, V> Collector<T, ?, TreePMap<K, V>> toTreePMap(
+      final Comparator<? super K> comparator,
+      final Function<? super T, ? extends K> keyMapper,
+      final Function<? super T, ? extends V> valueMapper
+  ) {
+    final BinaryOperator<V> mergeFunction = (oldValue, newValue) -> {
+      throw new IllegalStateException("duplicate key");
+    };
+
+    return toTreePMap(comparator, keyMapper, valueMapper, mergeFunction);
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePMap with mappings computed from the
+   * elements of the stream (using the specified keyMapper and valueMapper, with duplicates
+   * reconciled via the specified mergeFunction), in the order determined by the natural ordering of
+   * the keys.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param keyMapper  a function to compute the key from a stream element
+   * @param valueMapper  a function to compute the value from a stream element
+   * @param mergeFunction  a function to merge duplicate values
+   * @return a collector that gathers the elements of the stream into a TreePMap
+   * @throws NullPointerException  if any of this method's arguments are null
+   */
+  public static <T, K extends Comparable<? super K>, V> Collector<T, ?, TreePMap<K, V>> toTreePMap(
+      final Function<? super T, ? extends K> keyMapper,
+      final Function<? super T, ? extends V> valueMapper,
+      final BinaryOperator<V> mergeFunction
+  ) {
+    return toTreePMap(Comparator.naturalOrder(), keyMapper, valueMapper, mergeFunction);
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePMap with mappings computed from the
+   * elements of the stream (using the specified keyMapper and valueMapper, with duplicates
+   * reconciled via the specified mergeFunction), in the order determined by the specified
+   * comparator.
+   *
+   * @param <K>  the type of keys to be maintained by the map
+   * @param <V>  the type of mapped values
+   * @param comparator  the comparator according to which keys should be ordered
+   * @param keyMapper  a function to compute the key from a stream element
+   * @param valueMapper  a function to compute the value from a stream element
+   * @param mergeFunction  a function to merge duplicate values
+   * @return a collector that gathers the elements of the stream into a TreePMap
+   * @throws NullPointerException  if any of this method's arguments are null
+   */
+  public static <T, K, V> Collector<T, ?, TreePMap<K, V>> toTreePMap(
+      final Comparator<? super K> comparator,
+      final Function<? super T, ? extends K> keyMapper,
+      final Function<? super T, ? extends V> valueMapper,
+      final BinaryOperator<V> mergeFunction
+  ) {
+    complainIfNull(comparator, "comparator is null");
+    complainIfNull(keyMapper, "keyMapper is null");
+    complainIfNull(valueMapper, "valueMapper is null");
+    complainIfNull(mergeFunction, "mergeFunction is null");
+
+    final Supplier<TreeMap<K, V>> treeMapSupplier = () -> new TreeMap<K, V>(comparator);
+
+    final BiConsumer<TreeMap<K, V>, T> accumulator = (treeMap, element) -> {
+      complainIfNull(element, "stream element is null");
+
+      final K key = keyMapper.apply(element);
+      final V value = valueMapper.apply(element);
+
+      complainIfNull(key, "key is null");
+      complainIfNull(value, "value is null");
+
+      final V oldValue = treeMap.putIfAbsent(key, value);
+
+      if (oldValue != null) {
+        treeMap.put(key, mergeFunction.apply(oldValue, value));
+      }
+    };
+
+    final BinaryOperator<TreeMap<K, V>> combiner = (treeMap1, treeMap2) -> {
+      for (final Map.Entry<K, V> entry : treeMap2.entrySet()) {
+        final K key = entry.getKey();
+        final V value = entry.getValue();
+
+        final V oldValue = treeMap1.putIfAbsent(entry.getKey(), entry.getValue());
+
+        if (oldValue != null) {
+          treeMap1.put(key, mergeFunction.apply(oldValue, value));
+        }
+      }
+      return treeMap1;
+    };
+
+    final Function<TreeMap<K, V>, TreePMap<K, V>> finisher = TreePMap::fromSortedMap;
+
+    return Collector.<T, TreeMap<K, V>, TreePMap<K, V>>of(
+        treeMapSupplier,
+        accumulator,
+        combiner,
+        finisher);
+  }
+
+  @Override
+  public Map.Entry<K, V> ceilingEntry(final K key) {
+    return this.search(key, KVTree.SearchType.GE, KVTree.SearchType.LE).orNullIfEmpty();
+  }
+
+  @Override
+  public K ceilingKey(final K key) {
+    return this.search(key, KVTree.SearchType.GE, KVTree.SearchType.LE).getKey();
+  }
+
+  @Override
+  public Comparator<? super K> comparator() {
+    return this.isLeftToRight ? this.ltrComparator : this.ltrComparator.reversed();
+  }
+
+  @Override
+  public boolean containsKey(final Object key) {
+    return this.get(key) != null;
+  }
+
+  @Override
+  public PSortedSet<K> descendingKeySet() {
+    return new TreePSet<>(this.tree, this.ltrComparator, !this.isLeftToRight);
+  }
+
+  @Override
+  public TreePMap<K, V> descendingMap() {
+    return new TreePMap<>(this.tree, this.ltrComparator, !this.isLeftToRight);
+  }
+
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    return new AbstractUnmodifiableSet<Map.Entry<K, V>>() {
+      @Override
+      public boolean contains(final Object o) {
+        if (! (o instanceof Map.Entry<?, ?>)) {
+          return false;
+        }
+        final Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
+        return entry.getValue() != null
+            && Objects.equals(TreePMap.this.get(entry.getKey()), entry.getValue());
+      }
+
+      @Override
+      public Iterator<Entry<K, V>> iterator() {
+        return TreePMap.this.tree.entryIterator(TreePMap.this.isLeftToRight);
+      }
+
+      @Override
+      public int size() {
+        return TreePMap.this.tree.size();
+      }
+    };
+  }
+
+  @Override
+  public Map.Entry<K, V> firstEntry() {
+    return (this.isLeftToRight ? this.tree.getLeftmost() : this.tree.getRightmost()).orNullIfEmpty();
+  }
+
+  @Override
+  public K firstKey() {
+    return (this.isLeftToRight ? this.tree.getLeftmost() : this.tree.getRightmost()).getKey();
+  }
+
+  @Override
+  public Map.Entry<K, V> floorEntry(final K key) {
+    return this.search(key, KVTree.SearchType.LE, KVTree.SearchType.GE).orNullIfEmpty();
+  }
+
+  @Override
+  public K floorKey(final K key) {
+    return this.search(key, KVTree.SearchType.LE, KVTree.SearchType.GE).getKey();
+  }
+
+  @Override
+  public V get(final Object key) {
+    return this.search(sneakilyDowncast(key), KVTree.SearchType.EQ, KVTree.SearchType.EQ).getValue();
+  }
+
+  @Override
+  public TreePMap<K, V> headMap(final K toKey) {
+    return this.headMap(toKey, false);
+  }
+
+  @Override
+  public TreePMap<K, V> headMap(final K toKey, final boolean inclusive) {
+    complainIfNull(toKey, "toKey is null");
+
+    if (this.isLeftToRight) {
+      return this.withTree(this.tree.rangeToLeft(toKey, inclusive, this.ltrComparator));
+    } else {
+      return this.withTree(this.tree.rangeToRight(toKey, inclusive, this.ltrComparator));
+    }
+  }
+
+  @Override
+  public Map.Entry<K, V> higherEntry(final K key) {
+    return this.search(key, KVTree.SearchType.GT, KVTree.SearchType.LT).orNullIfEmpty();
+  }
+
+  @Override
+  public K higherKey(final K key) {
+    return this.search(key, KVTree.SearchType.GT, KVTree.SearchType.LT).getKey();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return this.tree.isEmpty();
+  }
+
+  @Override
+  public TreePSet<K> keySet() {
+    return new TreePSet<K>(this.tree, this.ltrComparator, this.isLeftToRight);
+  }
+
+  @Override
+  public Map.Entry<K, V> lastEntry() {
+    return (this.isLeftToRight ? this.tree.getRightmost() : this.tree.getLeftmost()).orNullIfEmpty();
+  }
+
+  @Override
+  public K lastKey() {
+    return (this.isLeftToRight ? this.tree.getRightmost() : this.tree.getLeftmost()).getKey();
+  }
+
+  @Override
+  public Map.Entry<K, V> lowerEntry(final K key) {
+    return this.search(key, KVTree.SearchType.LT, KVTree.SearchType.GT).orNullIfEmpty();
+  }
+
+  @Override
+  public K lowerKey(final K key) {
+    return this.search(key, KVTree.SearchType.LT, KVTree.SearchType.GT).getKey();
+  }
+
+  @Override
+  public TreePMap<K, V> minus(final Object key) {
+    complainIfNull(key, "key is null");
+
+    return this.withTree(this.tree.minus(sneakilyDowncast(key), this.ltrComparator));
+  }
+
+  @Override
+  public TreePMap<K, V> minusAll(final Collection<?> keys) {
+    complainIfNull(keys, "keys is null");
+
+    KVTree<K, V> updatedTree = this.tree;
+    for (final Object key : keys) {
+      complainIfNull(key, "keys contains null element");
+
+      updatedTree = updatedTree.minus(sneakilyDowncast(key), this.ltrComparator);
+    }
+    return this.withTree(updatedTree);
+  }
+
+  @Override
+  public TreePMap<K, V> minusFirstEntry() {
+    return this.withTree(
+        this.isLeftToRight ? this.tree.minusLeftmost() : this.tree.minusRightmost());
+  }
+
+  @Override
+  public TreePMap<K, V> minusLastEntry() {
+    return this.withTree(
+        this.isLeftToRight ? this.tree.minusRightmost() : this.tree.minusLeftmost());
+  }
+
+  @Override
+  public TreePSet<K> navigableKeySet() {
+    return this.keySet();
+  }
+
+  @Override
+  public TreePMap<K, V> plus(final K key, final V value) {
+    complainIfNull(key, "key is null");
+    complainIfNull(value, "value is null");
+
+    return this.withTree(this.tree.plus(key, value, this.ltrComparator));
+  }
+
+  @Override
+  public TreePMap<K, V> plusAll(final Map<? extends K, ? extends V> map) {
+    complainIfNull(map, "map is null");
+
+    KVTree<K, V> updatedTree = this.tree;
+
+    for (final Map.Entry<? extends K, ? extends V> entry : map.entrySet()) {
+      final K key = entry.getKey();
+      final V value = entry.getValue();
+
+      complainIfNull(key, "map contains null key");
+      complainIfNull(value, "map contains null value");
+
+      updatedTree = updatedTree.plus(key, value, this.ltrComparator);
+    }
+
+    return this.withTree(updatedTree);
+  }
+
+  @Override
+  public int size() {
+    return this.tree.size();
+  }
+
+  @Override
+  public TreePMap<K, V> subMap(final K fromKey, final K toKey) {
+    return this.subMap(fromKey, true, toKey, false);
+  }
+
+  @Override
+  public TreePMap<K, V> subMap(
+      final K fromKey, final boolean fromInclusive,
+      final K toKey, final boolean toInclusive
+  ) {
+    complainIfNull(fromKey, "fromKey is null");
+    complainIfNull(toKey, "toKey is null");
+
+    if (this.comparator().compare(fromKey, toKey) > 0) {
+      throw new IllegalArgumentException("fromKey > toKey");
+    }
+
+    if (this.isLeftToRight) {
+      return this.withTree(
+          this.tree.range(fromKey, fromInclusive, toKey, toInclusive, this.ltrComparator));
+    } else {
+      return this.withTree(
+          this.tree.range(toKey, toInclusive, fromKey, fromInclusive, this.ltrComparator));
+    }
+  }
+  @Override
+  public TreePMap<K, V> tailMap(final K fromKey) {
+    return this.tailMap(fromKey, true);
+  }
+
+  @Override
+  public TreePMap<K, V> tailMap(final K fromKey, final boolean inclusive) {
+    complainIfNull(fromKey, "fromKey is null");
+
+    if (this.isLeftToRight) {
+      return this.withTree(this.tree.rangeToRight(fromKey, inclusive, this.ltrComparator));
+    } else {
+      return this.withTree(this.tree.rangeToLeft(fromKey, inclusive, this.ltrComparator));
+    }
+  }
+
+  private KVTree<K, V> search(
+      final K key,
+      final KVTree.SearchType searchTypeIfLeftToRight,
+      final KVTree.SearchType searchTypeIfRightToLeft
+  ) {
+    complainIfNull(key, "key is null");
+
+    return this.tree.search(
+        key,
+        this.ltrComparator,
+        this.isLeftToRight ? searchTypeIfLeftToRight : searchTypeIfRightToLeft);
+  }
+
+  private TreePMap<K, V> withTree(final KVTree<K, V> updatedTree) {
+    return updatedTree == this.tree
+            ? this
+            : new TreePMap<K, V>(updatedTree, this.ltrComparator, this.isLeftToRight);
+  }
+
+  private static void complainIfNull(final Object o, final String msg) {
+    if (o == null) {
+      throw new NullPointerException(msg);
+    }
+  }
+
+  // we put this in its own method, to limit the scope of the @SuppressWarnings:
+  @SuppressWarnings("unchecked")
+  private static <T> T sneakilyDowncast(final Object o) {
+    return (T) o;
+  }
+}

--- a/src/main/java/org/pcollections/TreePSet.java
+++ b/src/main/java/org/pcollections/TreePSet.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * <p>An implementation of {@link PSortedSet} based on a self-balancing binary search tree.</p>
+ *
+ * <p>Instances of this class are obtained via any of various static factory methods and static
+ * collector methods. These methods come in pairs, with one version that accepts an explicit
+ * comparator to use and one version that uses the natural ordering of the elements.</p>
+ *
+ * <p>All operations are guaranteed to complete within O(log n) time, except for plusAll and
+ * minusAll, whose time cost is equivalent to the corresponding sequence of calls to plus or minus.
+ * A complete iteration pass completes in O(n) time. A few operations -- namely comparator,
+ * descendingSet, isEmpty, and size -- complete in O(1) time.</p>
+ *
+ * @param <E>  the type of elements maintained by this set
+ *
+ * @author Ran Ari-Gur
+ * @since 3.2.0
+ */
+public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
+    implements PSortedSet<E>, Serializable
+{
+  private static final long serialVersionUID = 1L;
+
+  private final KVTree<E, ?> tree;
+  private final Comparator<? super E> ltrComparator;
+  private final boolean isLeftToRight;
+
+  /**
+   * Non-private only because also used by TreePMap.keySet(). No other code should use it from
+   * outside this class.
+   */
+  TreePSet(
+      final KVTree<E, ?> tree,
+      final Comparator<? super E> ltrComparator,
+      final boolean isLeftToRight
+  ) {
+    complainIfNull(tree, "tree is null");
+    complainIfNull(ltrComparator, "comparator is null");
+
+    this.tree = tree;
+    this.ltrComparator = ltrComparator;
+    this.isLeftToRight = isLeftToRight;
+  }
+
+  /**
+   * Returns an empty TreePSet using the natural ordering.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @return  an empty TreePSet using the natural ordering
+   */
+  public static <E extends Comparable<? super E>> TreePSet<E> empty() {
+    return TreePSet.empty(Comparator.naturalOrder());
+  }
+
+  /**
+   * Returns an empty TreePSet using the specified comparator.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param comparator  the comparator according to which elements should be ordered
+   * @return  an empty TreePSet using the specified comparator
+   * @throws NullPointerException  if comparator is null
+   */
+  public static <E> TreePSet<E> empty(final Comparator<? super E> comparator) {
+    return new TreePSet<E>(KVTree.empty(), comparator, true);
+  }
+
+  /**
+   * Returns a TreePSet with the specified elements, using their natural ordering.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param list  the elements to include
+   * @return  a TreePSet containing the elements of list and using the natural ordering
+   * @throws NullPointerException  if list is null or contains null
+   */
+  public static <E extends Comparable<? super E>> TreePSet<E> from(
+      final Collection<? extends E> list
+  ) {
+    return TreePSet.from(Comparator.naturalOrder(), list);
+  }
+
+  /**
+   * Returns a TreePSet with the specified comparator and elements.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param comparator  the comparator to use
+   * @param list
+   *          the collection of elements to include; may include duplicates, but the returned
+   *          TreePSet will not
+   * @return  a TreePSet with the specified comparator and elements
+   * @throws NullPointerException  if the comparator is null or the collection is or contains null
+   */
+  public static <E> TreePSet<E> from(
+      final Comparator<? super E> comparator,
+      final Collection<? extends E> list
+  ) {
+    return TreePSet.<E>empty(comparator).plusAll(list);
+  }
+
+  /**
+   * Returns a TreePSet with the same elements and ordering as the specified set. This is
+   * essentially equivalent to {@code TreePSet.from(set.comparator(), set)}, except that it
+   * gracefully handles a null comparator, and is much more efficient.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param set  the set whose elements and ordering to use
+   * @return  a TreePSet with the same elements and ordering as the specified set
+   * @throws NullPointerException  if the specified set is or contains null
+   */
+  public static <E> TreePSet<E> fromSortedSet(final SortedSet<E> set) {
+    complainIfNull(set, "set is null");
+
+    if (set instanceof TreePSet<?>) {
+      return (TreePSet<E>) set;
+    }
+
+    final KVTree<E, ?> tree = KVTree.fromKeyIterator(set.iterator());
+
+    // check for null elements:
+    {
+      final Iterator<? extends Map.Entry<E, ?>> treeIterator = tree.entryIterator(true);
+      while (treeIterator.hasNext()) {
+        complainIfNull(treeIterator.next().getKey(), "set contains null element");
+      }
+    }
+
+    final Comparator<? super E> thatComparator = set.comparator();
+    final Comparator<? super E> comparator =
+        thatComparator == null ? sneakilyDowncast(Comparator.naturalOrder()) : thatComparator;
+
+    return new TreePSet<E>(tree, comparator, true);
+  }
+
+  /**
+   * Returns a TreePSet with the specified elements, using their natural ordering.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param elements
+   *          the elements to include; may include duplicates, but the returned TreePSet will not
+   * @return  a TreePSet containing the specified elements and using their natural ordering
+   * @throws NullPointerException
+   *          if any of the specified elements is null, or if the varargs array-ref is itself null
+   */
+  @SafeVarargs
+  public static <E extends Comparable<? super E>> TreePSet<E> of(final E... elements) {
+    return of(Comparator.naturalOrder(), elements);
+  }
+
+  /**
+   * Returns a TreePSet with the specified comparator and elements.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param comparator  the comparator to use
+   * @param elements
+   *          the elements to include; may include duplicates, but the returned TreePSet will not
+   * @return  a TreePSet containing the specified elements and using the specified comparator
+   * @throws NullPointerException
+   *          if the specified comparator is null, or if any of the specified elements is null, or
+   *          if the varargs array-ref is itself null
+   */
+  @SafeVarargs
+  public static <E> TreePSet<E> of(final Comparator<? super E> comparator, final E... elements) {
+    return TreePSet.<E>empty(comparator).plusAll(Arrays.asList(elements));
+  }
+
+  /**
+   * Returns a TreePSet with a single element, using the natural ordering.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param e  the element
+   * @return  a TreePSet containing the specified element and using the natural ordering
+   * @throws NullPointerException  if the specified element is null
+   */
+  public static <E extends Comparable<? super E>> TreePSet<E> singleton(final E e) {
+    return TreePSet.singleton(Comparator.naturalOrder(), e);
+  }
+
+  /**
+   * Returns a TreePSet with a single element, using the specified comparator.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param comparator  the comparator according to which elements should be ordered
+   * @param e  the element
+   * @return  a TreePSet containing the specified element and using the specified comparator
+   * @throws NullPointerException  if either the comparator or the element is null
+   */
+  public static <E> TreePSet<E> singleton(final Comparator<? super E> comparator, final E e) {
+    return TreePSet.<E>empty(comparator).plus(e);
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePSet with the elements of that stream,
+   * using their natural ordering.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @return a collector that gathers the elements of the stream into a TreePSet that uses the
+   *         natural ordering
+   */
+  public static <E extends Comparable<? super E>> Collector<E, ?, TreePSet<E>> toTreePSet() {
+    return TreePSet.toTreePSet(Comparator.naturalOrder());
+  }
+
+  /**
+   * Returns a collector that gathers a stream into a TreePSet with the elements of that stream,
+   * using the specified comparator.
+   *
+   * @param <E>  the type of elements to be maintained by the set
+   * @param comparator  the comparator to use
+   * @return a collector that gathers the elements of the stream into a TreePSet that uses the
+   *         specified comparator
+   * @throws NullPointerException  if the comparator is null
+   */
+  public static <E> Collector<E, ?, TreePSet<E>> toTreePSet(
+      final Comparator<? super E> comparator
+  ) {
+    complainIfNull(comparator, "comparator is null");
+
+    return Collectors.collectingAndThen(
+        Collectors.toCollection(() -> new TreeSet<E>(comparator)),
+        set -> TreePSet.fromSortedSet(set));
+  }
+
+  @Override
+  public E ceiling(final E e) {
+    return this.search(e, KVTree.SearchType.GE, KVTree.SearchType.LE);
+  }
+
+  @Override
+  public Comparator<? super E> comparator() {
+    return this.isLeftToRight ? this.ltrComparator : this.ltrComparator.reversed();
+  }
+
+  @Override
+  public boolean contains(final Object e) {
+    return this.search(sneakilyDowncast(e), KVTree.SearchType.EQ, KVTree.SearchType.EQ) != null;
+  }
+
+  @Override
+  public Iterator<E> descendingIterator() {
+    return this.descendingSet().iterator();
+  }
+
+  @Override
+  public TreePSet<E> descendingSet() {
+    return new TreePSet<E>(this.tree, this.ltrComparator, ! this.isLeftToRight);
+  }
+
+  @Override
+  public E first() {
+    return (this.isLeftToRight ? this.tree.getLeftmost() : this.tree.getRightmost()).getKey();
+  }
+
+  @Override
+  public E floor(final E e) {
+    return this.search(e, KVTree.SearchType.LE, KVTree.SearchType.GE);
+  }
+
+  @Override
+  public TreePSet<E> headSet(final E toElement) {
+    return this.headSet(toElement, false);
+  }
+
+  @Override
+  public TreePSet<E> headSet(final E toElement, final boolean inclusive) {
+    complainIfNull(toElement, "toElement is null");
+
+    return this.withTree(
+        this.isLeftToRight
+          ? this.tree.rangeToLeft(toElement, inclusive, this.ltrComparator)
+          : this.tree.rangeToRight(toElement, inclusive, this.ltrComparator));
+  }
+
+  @Override
+  public E higher(final E e) {
+    return this.search(e, KVTree.SearchType.GT, KVTree.SearchType.LT);}
+
+  @Override
+  public Iterator<E> iterator() {
+    final Iterator<? extends Map.Entry<E, ?>> entryIterator =
+        this.tree.entryIterator(this.isLeftToRight);
+    return new Iterator<E>() {
+      @Override
+      public boolean hasNext() {
+        return entryIterator.hasNext();
+      }
+
+      @Override
+      public E next() {
+        return entryIterator.next().getKey();
+      }
+    };
+  }
+
+  @Override
+  public E last() {
+    return (this.isLeftToRight ? this.tree.getRightmost() : this.tree.getLeftmost()).getKey();
+  }
+
+  @Override
+  public E lower(final E e) {
+    return this.search(e, KVTree.SearchType.LT, KVTree.SearchType.GT);
+  }
+
+  @Override
+  public TreePSet<E> minus(final Object e) {
+    complainIfNull(e, "element is null");
+
+    return this.withTree(this.tree.minus(sneakilyDowncast(e), this.ltrComparator));
+  }
+
+  @Override
+  public TreePSet<E> minusAll(final Collection<?> list) {
+    complainIfNull(list, "list is null");
+
+    KVTree<E, ?> tree = this.tree;
+
+    for (final Object e : list) {
+      complainIfNull(e, "list contains null element");
+
+      tree = tree.minus(sneakilyDowncast(e), this.ltrComparator);
+    }
+
+    return this.withTree(tree);
+  }
+
+  @Override
+  public TreePSet<E> minusFirst() {
+    return this.withTree(
+        this.isLeftToRight ? this.tree.minusLeftmost() : this.tree.minusRightmost());
+  }
+
+  @Override
+  public TreePSet<E> minusLast() {
+    return this.withTree(
+        this.isLeftToRight ? this.tree.minusRightmost() : this.tree.minusLeftmost());
+  }
+
+  @Override
+  public TreePSet<E> plus(final E e) {
+    complainIfNull(e, "element is null");
+
+    return this.withTree(this.tree.plus(e, null, this.ltrComparator));
+  }
+
+  @Override
+  public TreePSet<E> plusAll(final Collection<? extends E> list) {
+    complainIfNull(list, "list is null");
+
+    KVTree<E, ?> tree = this.tree;
+
+    for (final E e : list) {
+      complainIfNull(e, "list contains null element");
+
+      tree = tree.plus(e, null, this.ltrComparator);
+    }
+
+    return this.withTree(tree);
+  }
+
+  @Override
+  public int size() {
+    return this.tree.size();
+  }
+
+  @Override
+  public TreePSet<E> subSet(final E fromElement, final E toElement) {
+    return this.subSet(fromElement, true, toElement, false);
+  }
+
+  @Override
+  public TreePSet<E> subSet(
+      final E fromElement, final boolean fromInclusive, final E toElement, final boolean toInclusive
+  ) {
+    complainIfNull(fromElement, "fromElement is null");
+    complainIfNull(fromElement, "toElement is null");
+
+    if (this.comparator().compare(fromElement, toElement) > 0) {
+      throw new IllegalArgumentException("fromElement > toElement");
+    }
+
+    return this.withTree(
+        this.isLeftToRight
+          ? this.tree.range(fromElement, fromInclusive, toElement, toInclusive, this.ltrComparator)
+          : this.tree.range(toElement, toInclusive, fromElement, fromInclusive, this.ltrComparator));
+  }
+
+  @Override
+  public TreePSet<E> tailSet(final E fromElement) {
+    return this.tailSet(fromElement, true);
+  }
+
+  private E search(
+      final E e,
+      final KVTree.SearchType searchTypeIfLeftToRight,
+      final KVTree.SearchType searchTypeIfRightToLeft
+  ) {
+    complainIfNull(e, "e is null");
+
+    return this.tree.search(
+        e,
+        this.ltrComparator,
+        this.isLeftToRight ? searchTypeIfLeftToRight : searchTypeIfRightToLeft
+      ).getKey();
+  }
+
+  @Override
+  public TreePSet<E> tailSet(final E fromElement, final boolean inclusive) {
+    complainIfNull(fromElement, "fromElement is null");
+
+    return this.withTree(
+        this.isLeftToRight
+          ? this.tree.rangeToRight(fromElement, inclusive, this.ltrComparator)
+          : this.tree.rangeToLeft(fromElement, inclusive, this.ltrComparator));
+  }
+
+  private TreePSet<E> withTree(final KVTree<E, ?> tree) {
+    return tree == this.tree ? this : new TreePSet<E>(tree, this.ltrComparator, this.isLeftToRight);
+  }
+
+  private static void complainIfNull(final Object o, final String msg) {
+    if (o == null) {
+      throw new NullPointerException(msg);
+    }
+  }
+
+  // we put this in its own method, to limit the scope of the @SuppressWarnings:
+  @SuppressWarnings("unchecked")
+  private static <T> T sneakilyDowncast(final Object o) {
+    return (T) o;
+  }
+}

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -1,0 +1,1339 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections.tests;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.pcollections.PSortedSet;
+import org.pcollections.TreePMap;
+import org.pcollections.TreePSet;
+import org.pcollections.tests.util.CompareInconsistentWithEquals;
+import org.pcollections.tests.util.StringOrderComparator;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.TestCase;
+
+public class TreePMapTest extends TestCase {
+  /**
+   * An empty TreePMap&lt;Integer, String&gt; using the natural ordering; useful in cases where type
+   * inference isn't clever enough to deduce the '&lt;Integer, String&gt;' on its own.
+   */
+  private static final TreePMap<Integer, String> EMPTY = TreePMap.empty();
+
+  private static final Random RANDOM = new Random();
+
+  private static final Comparator<Object> STRING_ORDER_COMPARATOR = StringOrderComparator.INSTANCE;
+
+  private static final Function<Object, String> STRINGIFY = String::valueOf;
+
+  public void testComparator() {
+    // If don't specify a comparator, should get Comparator.naturalOrder():
+    assertEquivalentComparator(treeMapOf().comparator(), EMPTY.comparator());
+
+    // . . . and, descendingMap():
+    assertEquivalentComparator(
+        treeMapOf().descendingMap().comparator(),
+        EMPTY.descendingMap().comparator());
+
+    // If do specify a comparator, should get it:
+    assertSame(STRING_ORDER_COMPARATOR, TreePMap.empty(STRING_ORDER_COMPARATOR).comparator());
+
+    // . . . and, descendingMap():
+    assertEquivalentComparator(
+        STRING_ORDER_COMPARATOR.reversed(),
+        TreePMap.empty(STRING_ORDER_COMPARATOR).descendingMap().comparator());
+  }
+
+  public void testDescendingKeySet() {
+    // Rather than doing deep assertions into the key-set, we just assert that it's an instance of
+    // TreePSet, that it has the right sequence, and that it has the right comparator. Beyond that,
+    // we rely on TreePSetTest to test that a TreePSet with these properties will behave correctly.
+
+    assertSame(TreePSet.class, EMPTY.descendingKeySet().getClass());
+    assertSame(TreePSet.class, EMPTY.descendingMap().descendingKeySet().getClass());
+
+    assertEquivalentState(
+        treeMapOf().descendingKeySet(),
+        EMPTY.descendingKeySet());
+    assertEquivalentState(
+        treeMapOf().descendingMap().descendingKeySet(),
+        EMPTY.descendingMap().descendingKeySet());
+
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingKeySet());
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingKeySet());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).keySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingKeySet());
+  }
+
+  public void testDescendingMap() {
+    assertEquivalentState(
+        treeMapOf().descendingMap(),
+        EMPTY.descendingMap());
+    assertEquivalentState(
+        treeMapOf().descendingMap().descendingMap(),
+        EMPTY.descendingMap().descendingMap());
+
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap());
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingMap());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().descendingMap());
+
+    // Note: descendingMap() differs from all the other producer methods, from a testing standpoint,
+    // in that it sets a flag in the returned TreePMap that almost all other TreePMap methods have
+    // to take into account in order to behave correctly. So all of the other test-methods here also
+    // test different aspects of the map returned by descendingMap(), in order to test whatever
+    // method they're trying to test.
+  }
+
+  public void testEmpty() {
+    assertEquivalentState(new TreeMap<>(), TreePMap.empty());
+
+    assertEquivalentState(
+        new TreeMap<>(STRING_ORDER_COMPARATOR),
+        TreePMap.empty(STRING_ORDER_COMPARATOR));
+
+    assertThrows(NullPointerException.class, () -> TreePMap.empty(null));
+  }
+
+  public void testEntrySet() {
+    final List<Subcase> subcases =
+        Arrays.asList(
+            new Subcase(treeMapOf(), EMPTY),
+            new Subcase(treeMapOf().descendingMap(), EMPTY.descendingMap()),
+            new Subcase(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5), treePMapOf(STRINGIFY, 1, 2, 3, 4, 5)),
+            new Subcase(
+                treeMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+                treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap()));
+
+    for (final Subcase subcase : subcases) {
+      final Set<Map.Entry<Integer, String>> expected = subcase.expected.entrySet();
+      final Set<Map.Entry<Integer, String>> actual = subcase.actual.entrySet();
+
+      assertSameSequence(expected, actual);
+
+      final List<Map.Entry<Integer, String>> entriesToTest = new ArrayList<>();
+      entriesToTest.add(entryOf(0, "0"));
+      entriesToTest.add(entryOf(1, null));
+      entriesToTest.addAll(expected);
+      if (! expected.isEmpty()) {
+        entriesToTest.add(entryOf(expected.iterator().next().getKey(), "wrong"));
+      }
+
+      for (final Map.Entry<Integer, String> entry : entriesToTest) {
+        assertEquals(expected.contains(entry), actual.contains(entry));
+
+        assertEquals(
+            expected.containsAll(Arrays.asList(entry)),
+            actual.containsAll(Arrays.asList(entry)));
+      }
+      assertFalse(actual.contains(null));
+      assertTrue(actual.containsAll(expected));
+      assertFalse(actual.containsAll(entriesToTest));
+
+      assertTrue(actual.equals(actual));
+      assertTrue(actual.equals(expected));
+      assertTrue(actual.equals(new HashSet<>(expected)));
+      assertTrue(actual.equals(subcase.expected.descendingMap().entrySet()));
+      assertFalse(actual.equals(null));
+      assertFalse(actual.equals(new Object()));
+      assertFalse(actual.equals((Object) subcase.actual));
+      assertFalse(actual.equals(subcase.actual.plus(0, "wrong").entrySet()));
+
+      assertEquals(expected.hashCode(), actual.hashCode());
+
+      assertEquals(expected.isEmpty(), actual.isEmpty());
+
+      final Iterator<Map.Entry<Integer, String>> iterator = actual.iterator();
+      while (iterator.hasNext()) {
+        iterator.next();
+        assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+      }
+      assertThrows(NoSuchElementException.class, () -> iterator.next());
+
+      assertEquals(expected.size(), actual.size());
+
+      assertEquals(Arrays.asList(expected.toArray()), Arrays.asList(actual.toArray()));
+
+      assertEquals(expected.toString(), actual.toString());
+
+      // assert that all mutators throw UnsupportedOperationException:
+      assertThrows(UnsupportedOperationException.class, () -> actual.add(null));
+      assertThrows(UnsupportedOperationException.class, () -> actual.addAll(Arrays.asList()));
+      assertThrows(UnsupportedOperationException.class, () -> actual.clear());
+      assertThrows(UnsupportedOperationException.class, () -> actual.remove(null));
+      assertThrows(UnsupportedOperationException.class, () -> actual.removeAll(null));
+      assertThrows(UnsupportedOperationException.class, () -> actual.removeIf(null));
+      assertThrows(UnsupportedOperationException.class, () -> actual.retainAll(null));
+      if (! expected.isEmpty()) {
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> actual.iterator().next().setValue("wrong"));
+      }
+    }
+  }
+
+  /**
+   * Test that TreePMap.equals(...) returns true for each of various maps that have the same size
+   * and mappings, and that it returns false for each of various objects that are not such map.
+   */
+  public void testEquals() {
+    final List<Subcase> subcases =
+        Arrays.asList(
+            new Subcase(treeMapOf(), EMPTY),
+            new Subcase(treeMapOf().descendingMap(), EMPTY.descendingMap()),
+            new Subcase(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5), treePMapOf(STRINGIFY, 1, 2, 3, 4, 5)),
+            new Subcase(
+                treeMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+                treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableMap<Integer, String> expected = subcase.expected;
+      final TreePMap<Integer, String> actual = subcase.actual;
+
+      // must return false for anything other than a map:
+      assertFalse(actual.equals(null));
+      assertFalse(actual.equals(new Object()));
+      assertFalse(actual.equals((Object) "foo"));
+      assertFalse(actual.equals((Object) actual.keySet()));
+      assertFalse(actual.equals((Object) actual.entrySet()));
+
+      // must return true for a map with the same mappings:
+      assertTrue(actual.equals(actual));
+      assertTrue(actual.equals(expected));
+      assertTrue(actual.equals((Object) new LinkedHashMap<>(expected)));
+      // . . . even if the iteration order is different:
+      assertTrue(actual.equals((Object) new HashMap<>(expected)));
+      assertTrue(actual.equals(actual.descendingMap()));
+      assertTrue(actual.equals(expected.descendingMap()));
+
+      // must return false for a map that's too small:
+      if (! actual.isEmpty()) {
+        final TreeMap<Integer, String> tooSmall = new TreeMap<>(expected);
+        tooSmall.pollFirstEntry();
+        assertFalse(actual.equals((Object) tooSmall));
+      }
+
+      // must return false for a map that's too big:
+      {
+        final HashMap<Integer, String> tooBig = new HashMap<>(expected);
+        tooBig.put(findSomeNonKey(actual), "extra");
+        assertFalse(actual.equals((Object) tooBig));
+      }
+
+      // must return false for a map that has a wrong mapping:
+      if (! actual.isEmpty()) {
+        final TreeMap<Integer, String> wrong = new TreeMap<>(expected);
+        wrong.put(wrong.firstKey(), "wrong");
+        assertFalse(actual.equals((Object) wrong));
+      }
+    }
+  }
+
+  public void testFrom() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      assertEquivalentState(new TreeMap<>(map), TreePMap.from(map));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePMap.from(null));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.from(Collections.singletonMap(null, "foo")));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.from(Collections.singletonMap("foo", null)));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      final TreeMap<Integer, String> expected = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      expected.putAll(map);
+
+      assertEquivalentState(
+          expected,
+          TreePMap.from(STRING_ORDER_COMPARATOR, map));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePMap.from(null, new HashMap<>()));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.from(STRING_ORDER_COMPARATOR, null));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.from(STRING_ORDER_COMPARATOR, Collections.singletonMap(null, "foo")));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.from(STRING_ORDER_COMPARATOR, Collections.singletonMap("foo", null)));
+  }
+
+  public void testFromSortedMap() {
+    // if SortedMap has null comparator, use natural-ordering comparator:
+    {
+      final TreeMap<Integer, String> expected = new TreeMap<>();
+      for (int i = 0; i < 20; ++i) {
+        expected.put(RANDOM.nextInt(), randomString());
+      }
+
+      assertEquivalentState(expected, TreePMap.fromSortedMap(expected));
+    }
+
+    // if SortedMap has explicit comparator, use it:
+    {
+      final TreeMap<Integer, String> expected = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      for (int i = 0; i < 20; ++i) {
+        expected.put(RANDOM.nextInt(), randomString());
+      }
+
+      assertEquivalentState(expected, TreePMap.fromSortedMap(expected));
+    }
+
+    // if SortedMap is actually already a TreePMap, just use it as-is:
+    {
+      TreePMap<Integer, String> expected = TreePMap.empty(STRING_ORDER_COMPARATOR);
+      for (int i = 0; i < 20; ++i) {
+        expected = expected.plus(RANDOM.nextInt(), randomString());
+      }
+
+      assertSame(expected, TreePMap.fromSortedMap(expected));
+    }
+
+    // if SortedMap is actually null, complain:
+    assertThrows(NullPointerException.class, () -> TreePMap.fromSortedMap(null));
+
+    // if SortedMap contains null key, complain:
+    {
+      final TreeMap<Integer, String> containsNullKey = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      containsNullKey.put(RANDOM.nextInt(), randomString());
+      containsNullKey.put(null, randomString());
+
+      assertThrows(NullPointerException.class, () -> TreePMap.fromSortedMap(containsNullKey));
+    }
+
+    // if SortedMap contains null value, complain:
+    {
+      final TreeMap<Integer, String> containsNullValue = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      containsNullValue.put(RANDOM.nextInt(), randomString());
+      containsNullValue.put(RANDOM.nextInt(), null);
+
+      assertThrows(NullPointerException.class, () -> TreePMap.fromSortedMap(containsNullValue));
+    }
+  }
+
+  public void testHashCode() {
+    assertEquals(
+        treeMapOf().hashCode(),
+        EMPTY.hashCode());
+    assertEquals(
+        treeMapOf().descendingMap().hashCode(),
+        EMPTY.descendingMap().hashCode());
+
+    assertEquals(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).hashCode(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).hashCode());
+    assertEquals(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().hashCode(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().hashCode());
+  }
+
+  /**
+   * Verifies that, when comparison is not consistent with equals, that TreePMap honors the former
+   * rather than the latter.
+   */
+  public void testInconsistentWithEquals() {
+    final TreeMap<CompareInconsistentWithEquals, String> expected = new TreeMap<>();
+
+    TreePMap<CompareInconsistentWithEquals, String> actual = TreePMap.empty();
+
+    for (int i = 0 ; i < 20; ++i) {
+      final int randomEq1 = RANDOM.nextInt();
+      final int randomEq2 = RANDOM.nextInt();
+      final int randomComp1 = RANDOM.nextInt();
+      final int randomComp2 = RANDOM.nextInt();
+
+      final List<CompareInconsistentWithEquals> keysToPut = Arrays.asList(
+          new CompareInconsistentWithEquals(randomEq1, randomComp1),
+          new CompareInconsistentWithEquals(randomEq1, randomComp2),
+          new CompareInconsistentWithEquals(randomEq2, randomComp1),
+          new CompareInconsistentWithEquals(randomEq2, randomComp2));
+
+      for (final CompareInconsistentWithEquals key : keysToPut) {
+        final String value = key.toString();
+        expected.put(key, value);
+        actual = actual.plus(key, value);
+      }
+    }
+
+    assertEquals(expected.size(), actual.size());
+
+    final Iterator<Map.Entry<CompareInconsistentWithEquals, String>> actualIterator =
+        actual.entrySet().iterator();
+    for (final Map.Entry<CompareInconsistentWithEquals, String> expectedEntry : expected.entrySet()) {
+      final Map.Entry<CompareInconsistentWithEquals, String> actualEntry = actualIterator.next();
+      assertSame(expectedEntry.getKey(), actualEntry.getKey());
+      assertEquals(expectedEntry.getValue(), actualEntry.getValue());
+    }
+  }
+
+  public void testIsEmpty() {
+    assertTrue(EMPTY.isEmpty());
+    assertTrue(EMPTY.descendingMap().isEmpty());
+
+    assertFalse(treePMapOf(STRINGIFY, 1, 2, 3, 4).isEmpty());
+    assertFalse(treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().isEmpty());
+  }
+
+  public void testKeySet() {
+    // Rather than doing deep assertions into the key-set, we just assert that it's an instance of
+    // TreePSet, that it has the right sequence, and that it has the right comparator. Beyond that,
+    // we rely on TreePSetTest to test that a TreePSet with these properties will behave correctly.
+
+    assertSame(TreePSet.class, EMPTY.keySet().getClass());
+    assertSame(TreePSet.class, EMPTY.descendingMap().keySet().getClass());
+
+    assertEquivalentState(
+        treeMapOf().navigableKeySet(),
+        EMPTY.keySet());
+    assertEquivalentState(
+        treeMapOf().descendingMap().navigableKeySet(),
+        EMPTY.descendingMap().keySet());
+
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).navigableKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).keySet());
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().navigableKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().keySet());
+  }
+
+  /**
+   * This test ensures that we cover all the different cases in KVTree.join (meaning, all the
+   * different relative heights of left.left, left.right, right.left, and right.right that have to
+   * be handled in different ways), because some of them have low probability of occurring randomly.
+   */
+  public void testKVTreeJoin() {
+    /** a perfect tree of height 3 */
+    final TreePMap<Integer, String> oneToSeven = treePMapOf(STRINGIFY, 1, 2, 3, 4, 5, 6, 7);
+    /** a perfect tree of height 4 */
+    final TreePMap<Integer, String> oneToFifteen =
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+    // case where left.height < right.height - 2:
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 8, 9, 10, 11, 12, 13, 14, 15),
+        oneToFifteen.tailMap(8, true));
+
+    // case where left.height == right.height - 2 and right.left.height <= right.right.height:
+    assertEquivalentState(treeMapOf(STRINGIFY, 4, 6, 7), oneToSeven.minus(5).tailMap(4, true));
+
+    // case where left.height == right.height - 2 and right.left.height > right.right.height:
+    assertEquivalentState(treeMapOf(STRINGIFY, 4, 5, 6), oneToSeven.minus(7).tailMap(4, true));
+
+    // skip case where |left.height - right.height| <= 1 -- this happens naturally all the time
+    // (including in this method), no special coverage needed
+
+    // case where left.height == right.height + 2 and left.left.height < left.right.height:
+    assertEquivalentState(treeMapOf(STRINGIFY, 2, 3, 4), oneToSeven.minus(1).headMap(4, true));
+
+    // case where left.height == right.height + 2 and left.left.height >= left.right.height:
+    assertEquivalentState(treeMapOf(STRINGIFY, 1, 2, 4), oneToSeven.minus(3).headMap(4, true));
+
+    // case where left.height > right.height + 2:
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4, 5, 6, 7, 8),
+        oneToFifteen.headMap(8, true));
+  }
+
+
+  /** Perform a few simple validations on a largish random map (just as a sanity-check). */
+  public void testLargishRandomMap() {
+    final TreeMap<Integer, String> expected = new TreeMap<>();
+    TreePMap<Integer, String> actual = TreePMap.empty();
+
+    for (int i = 0; i < 20_000; ++i) {
+      final Integer keyToPut = RANDOM.nextInt();
+      final String valueToPut = randomString();
+      expected.put(keyToPut, valueToPut);
+      actual = actual.plus(keyToPut, valueToPut);
+    }
+
+    assertEquivalentState(expected, actual);
+    assertEquivalentState(expected.descendingMap(), actual.descendingMap());
+
+    assertTrue(actual.entrySet().containsAll(expected.entrySet()));
+
+    {
+      final int a = RANDOM.nextInt();
+      final int b = RANDOM.nextInt();
+
+      final int from = Math.min(a, b);
+      final int to = Math.max(a, b);
+
+      assertEquivalentState(expected.subMap(from, to), actual.subMap(from, to));
+      assertEquivalentState(
+          expected.descendingMap().subMap(to, from),
+          actual.descendingMap().subMap(to, from));
+    }
+  }
+
+  public void testMinusAll() {
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.minusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        EMPTY,
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 3, 5),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).minusAll(Arrays.asList(0, 2, 4, 6)));
+
+    assertEquivalentState(
+        EMPTY.descendingMap(),
+        EMPTY.descendingMap().minusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        EMPTY.descendingMap(),
+        EMPTY.descendingMap().minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        EMPTY.descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 3, 5).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().minusAll(Arrays.asList(0, 2, 4, 6)));
+
+    assertThrows(NullPointerException.class, () -> EMPTY.minusAll(null));
+    assertThrows(NullPointerException.class, () -> EMPTY.minusAll(Arrays.asList(0, null)));
+  }
+
+  public void testMinusFirstEntry() {
+    assertThrows(NoSuchElementException.class, () -> EMPTY.minusFirstEntry());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 2, 3, 4, 5),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).minusFirstEntry());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().minusFirstEntry());
+  }
+
+  public void testMinusLastEntry() {
+    assertThrows(NoSuchElementException.class, () -> EMPTY.minusLastEntry());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).minusLastEntry());
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 2, 3, 4, 5).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().minusLastEntry());
+  }
+
+  /**
+   * Test that clear(), compute(...), computeIfAbsent(...), computeIfPresent(...), merge(...),
+   * pollFirstEntry(), pollLastEntry(), put(...), putAll(...), remove(...), replace(...), and
+   * replaceAll(...) all throw UnsupportedOperationException.
+   */
+  @SuppressWarnings("deprecation")
+  public void testMutators() {
+    final TreePMap<Integer, String> map = treePMapOf(STRINGIFY, 1, 2, 3, 4);
+
+    assertThrows(UnsupportedOperationException.class, () -> map.clear());
+    assertThrows(UnsupportedOperationException.class, () -> map.compute(10, (i, s) -> "10"));
+    assertThrows(UnsupportedOperationException.class, () -> map.computeIfAbsent(10, i -> "10"));
+    assertThrows(UnsupportedOperationException.class, () -> map.computeIfPresent(10, (i, s) -> s));
+    assertThrows(UnsupportedOperationException.class, () -> map.merge(10, "10", (s1, s2) -> s2));
+    assertThrows(UnsupportedOperationException.class, () -> map.pollFirstEntry());
+    assertThrows(UnsupportedOperationException.class, () -> map.pollLastEntry());
+    assertThrows(UnsupportedOperationException.class, () -> map.put(10, "10"));
+    assertThrows(UnsupportedOperationException.class, () -> map.putAll(Collections.emptyMap()));
+    assertThrows(UnsupportedOperationException.class, () -> map.putIfAbsent(10, "10"));
+    assertThrows(UnsupportedOperationException.class, () -> map.remove(10));
+    assertThrows(UnsupportedOperationException.class, () -> map.replace(10, "10"));
+    assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((i, s) -> s));
+  }
+
+  public void testNavigableKeySet() {
+    // Rather than doing deep assertions into the key-set, we just assert that it's an instance of
+    // TreePSet, that it has the right sequence, and that it has the right comparator. Beyond that,
+    // we rely on TreePSetTest to test that a TreePSet with these properties will behave correctly.
+
+    assertSame(TreePSet.class, EMPTY.navigableKeySet().getClass());
+    assertSame(TreePSet.class, EMPTY.descendingMap().navigableKeySet().getClass());
+
+    assertEquivalentState(
+        treeMapOf().navigableKeySet(),
+        EMPTY.navigableKeySet());
+    assertEquivalentState(
+        treeMapOf().descendingMap().navigableKeySet(),
+        EMPTY.descendingMap().navigableKeySet());
+
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).navigableKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).navigableKeySet());
+    assertEquivalentState(
+        treeMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().navigableKeySet(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().navigableKeySet());
+  }
+
+  public void testPlusAndMinus() {
+    final List<Subcase> subcases =
+        Arrays.asList(
+            new Subcase(treeMapOf(), EMPTY),
+            new Subcase(treeMapOf().descendingMap(), EMPTY.descendingMap()),
+            new Subcase(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5), treePMapOf(STRINGIFY, 1, 2, 3, 4, 5)),
+            new Subcase(
+                treeMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+                treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableMap<Integer, String> expected = subcase.expected;
+      final TreePMap<Integer, String> actual = subcase.actual;
+
+      final ArrayList<Integer> keysToTest = new ArrayList<>();
+      keysToTest.add(0);
+      for (final int i : expected.keySet()) {
+        keysToTest.add(i - 1);
+        keysToTest.add(i);
+        keysToTest.add(i + 1);
+      }
+
+      for (final Integer key : keysToTest) {
+        final String originalValue = expected.get(key);
+
+        expected.put(key, "x");
+        assertEquivalentState(expected, actual.plus(key, "x"));
+
+        expected.remove(key);
+        assertEquivalentState(expected, actual.minus(key));
+
+        if (originalValue != null) {
+          expected.put(key, originalValue);
+        }
+      }
+
+      assertThrows(NullPointerException.class, () -> actual.plus(null, "foo"));
+      assertThrows(NullPointerException.class, () -> actual.plus(0, null));
+      assertThrows(NullPointerException.class, () -> actual.minus(null));
+    }
+  }
+
+  public void testPlusAll() {
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.plusAll(Collections.emptyMap()));
+    assertEquivalentState(
+        EMPTY.descendingMap(),
+        EMPTY.descendingMap().plusAll(Collections.emptyMap()));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5),
+        EMPTY.plusAll(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5)));
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+        EMPTY.descendingMap().plusAll(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).plusAll(Collections.emptyMap()));
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().plusAll(Collections.emptyMap()));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5),
+        treePMapOf(STRINGIFY, 1, 3, 5).plusAll(treeMapOf(STRINGIFY, 2, 3, 4)));
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 3, 5).descendingMap().plusAll(treeMapOf(STRINGIFY, 2, 3, 4)));
+
+    final Function<Integer, String> evenOrStringify = (i -> i % 2 == 0 ? "even" : i.toString());
+
+    assertEquivalentState(
+        treePMapOf(evenOrStringify, 1, 2, 3, 4, 5),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).plusAll(treeMapOf(evenOrStringify, 2, 3, 4)));
+    assertEquivalentState(
+        treePMapOf(evenOrStringify, 1, 2, 3, 4, 5).descendingMap(),
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().plusAll(treeMapOf(evenOrStringify, 2, 3, 4)));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> EMPTY.plusAll(null));
+    assertThrows(
+        NullPointerException.class,
+        () -> EMPTY.plusAll(Collections.singletonMap(null, "foo")));
+    assertThrows(
+        NullPointerException.class,
+        () -> EMPTY.plusAll(Collections.singletonMap(3, null)));
+  }
+
+  /**
+   * Test headMap(), subMap(), and tailMap() -- both the overloads with the 'isInclusive'
+   * parameter(s) and the overloads without.
+   */
+  public void testRanges() {
+    final List<Subcase> subcases =
+        Arrays.asList(
+            new Subcase(treeMapOf(), EMPTY),
+            new Subcase(treeMapOf().descendingMap(), EMPTY.descendingMap()),
+            new Subcase(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5), treePMapOf(STRINGIFY, 1, 2, 3, 4, 5)),
+            new Subcase(
+                treeMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+                treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableMap<Integer, String> expected = subcase.expected;
+      final TreePMap<Integer, String> actual = subcase.actual;
+
+      final ArrayList<Integer> bounds = new ArrayList<>();
+      bounds.add(0);
+      for (final int i : expected.keySet()) {
+        bounds.add(i - 1);
+        bounds.add(i);
+        bounds.add(i + 1);
+      }
+
+      for (final int to : bounds) {
+        assertEquivalentState(expected.headMap(to), actual.headMap(to));
+        assertEquivalentState(expected.headMap(to, true), actual.headMap(to, true));
+        assertEquivalentState(expected.headMap(to, false), actual.headMap(to, false));
+
+        for (final int from : bounds) {
+          if (actual.comparator().compare(from, to) <= 0) {
+            assertEquivalentState(
+                expected.subMap(from, to),
+                actual.subMap(from, to));
+            assertEquivalentState(
+                expected.subMap(from, true, to, true),
+                actual.subMap(from, true, to, true));
+            assertEquivalentState(
+                expected.subMap(from, true, to, false),
+                actual.subMap(from, true, to, false));
+            assertEquivalentState(
+                expected.subMap(from, false, to, true),
+                actual.subMap(from, false, to, true));
+            assertEquivalentState(
+                expected.subMap(from, false, to, false),
+                actual.subMap(from, false, to, false));
+          } else {
+            assertThrows(IllegalArgumentException.class, () -> actual.subMap(from, to));
+            assertThrows(IllegalArgumentException.class, () -> actual.subMap(from, true, to, true));
+            assertThrows(IllegalArgumentException.class, () -> actual.subMap(from, true, to, false));
+            assertThrows(IllegalArgumentException.class, () -> actual.subMap(from, false, to, true));
+            assertThrows(IllegalArgumentException.class, () -> actual.subMap(from, false, to, false));
+          }
+        }
+      }
+
+      for (final int from : bounds) {
+        assertEquivalentState(expected.tailMap(from), actual.tailMap(from));
+        assertEquivalentState(expected.tailMap(from, true), actual.tailMap(from, true));
+        assertEquivalentState(expected.tailMap(from, false), actual.tailMap(from, false));
+      }
+
+      assertThrows(NullPointerException.class, () -> actual.headMap(null));
+      assertThrows(NullPointerException.class, () -> actual.headMap(null, true));
+      assertThrows(NullPointerException.class, () -> actual.subMap(null, 0));
+      assertThrows(NullPointerException.class, () -> actual.subMap(null, true, 0, true));
+      assertThrows(NullPointerException.class, () -> actual.subMap(0, null));
+      assertThrows(NullPointerException.class, () -> actual.subMap(0, true, null, true));
+      assertThrows(NullPointerException.class, () -> actual.tailMap(null));
+      assertThrows(NullPointerException.class, () -> actual.tailMap(null, true));
+    }
+  }
+
+  /**
+   * Test ceilingEntry(...), ceilingKey(...), containsKey(...), containsValue(), firstEntry(),
+   * firstKey(), floorEntry(...), floorKey(...), get(...), getOrDefault(...), higherEntry(...),
+   * higherKey(...), lastEntry(), lastKey(), lowerEntry(...), and lowerKey(...), by validating that
+   * they give the same result for a TreePMap as for a TreeMap.
+   */
+  public void testSearchers() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeMapOf(), EMPTY),
+        new Subcase(treeMapOf().descendingMap(), EMPTY.descendingMap()),
+        new Subcase(treeMapOf(STRINGIFY, 1, 2, 3, 4, 5), treePMapOf(STRINGIFY, 1, 2, 3, 4, 5)),
+        new Subcase(
+            treeMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap(),
+            treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap()),
+        new Subcase(treeMapOf(STRINGIFY, 1, 3, 5, 7, 9), treePMapOf(STRINGIFY, 1, 3, 5, 7, 9)),
+        new Subcase(
+            treeMapOf(STRINGIFY, 1, 3, 5, 7, 9).descendingMap(),
+            treePMapOf(STRINGIFY, 1, 3, 5, 7, 9).descendingMap()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableMap<Integer, String> expected = subcase.expected;
+      final TreePMap<Integer, String> actual = subcase.actual;
+
+      // ensure that we have an key to test even if expected is empty:
+      final Iterable<Integer> keysToTest = expected.isEmpty() ? Arrays.asList(0) : expected.keySet();
+
+      for (final int key : keysToTest) {
+        for (final int arg : new int[] { key - 1, key, key + 1 }) {
+          assertEquals(expected.ceilingEntry(arg), actual.ceilingEntry(arg));
+          assertEquals(expected.ceilingKey(arg), actual.ceilingKey(arg));
+          assertEquals(expected.containsKey(arg), actual.containsKey(arg));
+          assertEquals(expected.floorEntry(arg), actual.floorEntry(arg));
+          assertEquals(expected.floorKey(arg), actual.floorKey(arg));
+          assertEquals(expected.get(arg), actual.get(arg));
+          assertEquals(expected.getOrDefault(arg, "default"), actual.getOrDefault(arg, "default"));
+          assertEquals(expected.higherEntry(arg), actual.higherEntry(arg));
+          assertEquals(expected.higherKey(arg), actual.higherKey(arg));
+          assertEquals(expected.lowerEntry(arg), actual.lowerEntry(arg));
+          assertEquals(expected.lowerKey(arg), actual.lowerKey(arg));
+        }
+      }
+
+      for (final String value : expected.values()) {
+        assertTrue(actual.containsValue(value));
+      }
+      assertFalse(actual.containsValue("wrong"));
+
+      if (expected.isEmpty()) {
+        assertThrows(NoSuchElementException.class, actual::firstEntry);
+        assertThrows(NoSuchElementException.class, actual::firstKey);
+        assertThrows(NoSuchElementException.class, actual::lastEntry);
+        assertThrows(NoSuchElementException.class, actual::lastKey);
+      } else {
+        assertEquals(expected.firstEntry(), actual.firstEntry());
+        assertEquals(expected.firstKey(), actual.firstKey());
+        assertEquals(expected.lastEntry(), actual.lastEntry());
+        assertEquals(expected.lastKey(), actual.lastKey());
+      }
+    }
+  }
+
+  public void testSerializeAndDeserialize() throws Exception {
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4),
+        serializeAndDeserialize(treePMapOf(STRINGIFY, 1, 2, 3, 4)));
+
+    assertEquivalentState(
+        treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap(),
+        serializeAndDeserialize(treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap()));
+
+    assertEquivalentState(
+        treePMapOf(STRING_ORDER_COMPARATOR, STRINGIFY, 1, 2, 3, 4),
+        serializeAndDeserialize(treePMapOf(STRING_ORDER_COMPARATOR, STRINGIFY, 1, 2, 3, 4)));
+
+    assertEquivalentState(
+        treePMapOf(STRING_ORDER_COMPARATOR, STRINGIFY, 1, 2, 3, 4).descendingMap(),
+        serializeAndDeserialize(
+            treePMapOf(STRING_ORDER_COMPARATOR, STRINGIFY, 1, 2, 3, 4).descendingMap()));
+  }
+
+  public void testSingleton() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    assertEquivalentState(
+        new TreeMap<>(Collections.singletonMap(3, "foo")),
+        TreePMap.singleton(3, "foo"));
+
+    assertThrows(NullPointerException.class, () -> TreePMap.singleton(null, "foo"));
+    assertThrows(NullPointerException.class, () -> TreePMap.singleton(3, null));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final TreeMap<Integer, String> expected = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      expected.put(17, "yes");
+
+      assertEquivalentState(expected, TreePMap.singleton(STRING_ORDER_COMPARATOR, 17, "yes"));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePMap.singleton(null, 3, "foo"));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.singleton(STRING_ORDER_COMPARATOR, null, "foo"));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.singleton(STRING_ORDER_COMPARATOR, "foo", null));
+  }
+
+  public void testSize() {
+    assertEquals(0, EMPTY.size());
+    assertEquals(0, EMPTY.descendingMap().size());
+
+    assertEquals(4, treePMapOf(STRINGIFY, 1, 2, 3, 4).size());
+    assertEquals(4, treePMapOf(STRINGIFY, 1, 2, 3, 4).descendingMap().size());
+  }
+
+  public void testToString() {
+    // empty map:
+    assertEquals("{}", EMPTY.toString());
+    assertEquals("{}", EMPTY.descendingMap().toString());
+
+    // singleton map -- no commas:
+    assertEquals("{1=1}", treePMapOf(STRINGIFY, 1).toString());
+    assertEquals("{1=1}", treePMapOf(STRINGIFY, 1).descendingMap().toString());
+
+    // map with multiple mappings -- separated with comma + space, and order matters:
+    assertEquals(
+        "{1=1, 2=2, 3=3, 4=4, 5=5}",
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).toString());
+    assertEquals(
+        "{5=5, 4=4, 3=3, 2=2, 1=1}",
+        treePMapOf(STRINGIFY, 1, 2, 3, 4, 5).descendingMap().toString());
+  }
+
+  public void testToTreePMap() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering) or explicit
+    // merge function (throws IllegalStateException on duplicate keys):
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      assertEquivalentState(
+          new TreeMap<>(map),
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(entry -> null, Map.Entry::getValue)));
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(Map.Entry::getKey, entry -> null)));
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(entry -> "duplicate key", Map.Entry::getValue)));
+    }
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(null, Function.identity()));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(Function.identity(), null));
+
+    // the overload that takes an explicit comparator, but not an explicit merge function (throws
+    // IllegalStateException on duplicate keys):
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      final TreeMap<Integer, String> expected = new TreeMap<>(STRING_ORDER_COMPARATOR);
+      expected.putAll(map);
+
+      assertEquivalentState(
+          expected,
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, Map.Entry::getKey, Map.Entry::getValue)));
+
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, entry -> null, Map.Entry::getValue)));
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, Map.Entry::getKey, entry -> null)));
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, entry -> "duplicate", Map.Entry::getValue)));
+    }
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(null, Function.identity(), STRINGIFY));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(STRING_ORDER_COMPARATOR, null, STRINGIFY));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(STRING_ORDER_COMPARATOR, Function.identity(), null));
+
+    // the overload that doesn't take an explicit comparator (uses natural ordering) but does take
+    // an explicit merge function:
+
+    final BinaryOperator<String> mergeFunction = (oldValue, newValue) -> {
+      final List<String> mergedValue = new ArrayList<>();
+      mergedValue.addAll(Arrays.asList(oldValue.split(":")));
+      mergedValue.addAll(Arrays.asList(newValue.split(":")));
+      Collections.sort(mergedValue);
+      return String.join(":", mergedValue);
+    };
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      assertEquivalentState(
+          new TreeMap<>(map),
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(Map.Entry::getKey, Map.Entry::getValue, mergeFunction)));
+
+      // map all entries to duplicate key, to exercise merge function:
+      assertEquivalentState(
+          new TreeMap<>(Collections.singletonMap(
+              3,
+              map.values().parallelStream().sorted().collect(Collectors.joining(":")))),
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(entry -> 3, Map.Entry::getValue, mergeFunction)));
+
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(entry -> null, Map.Entry::getValue, mergeFunction)));
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(Map.Entry::getKey, entry -> null, mergeFunction)));
+    }
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(null, Function.identity(), mergeFunction));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(Function.identity(), null, mergeFunction));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            TreePMap.<Map.Entry<Integer, String>, Integer, String>toTreePMap(
+                Map.Entry::getKey, Map.Entry::getValue, (BinaryOperator<String>) null));
+
+    // the overload that takes an explicit comparator and an explicit merge function (reusing the
+    // 'mergeFunction' from the previous section):
+
+    {
+      final Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 20; ++i) {
+        map.put(RANDOM.nextInt(), randomString());
+      }
+
+      final TreeMap<Integer, String> expected = new TreeMap<>(STRING_ORDER_COMPARATOR);
+
+      expected.putAll(map);
+      assertEquivalentState(
+          expected,
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR,
+                      Map.Entry::getKey,
+                      Map.Entry::getValue,
+                      mergeFunction)));
+
+      // map all entries to duplicate key, to exercise merge function:
+      expected.clear();
+      expected.put(3, map.values().stream().sorted().collect(Collectors.joining(":")));
+      assertEquivalentState(
+          expected,
+          map.entrySet().parallelStream()
+              .collect(TreePMap.toTreePMap(
+                  STRING_ORDER_COMPARATOR, entry -> 3, Map.Entry::getValue, mergeFunction)));
+
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, entry -> null, Map.Entry::getValue, mergeFunction)));
+      assertThrows(
+          NullPointerException.class,
+          () ->
+              map.entrySet().parallelStream()
+                  .collect(TreePMap.toTreePMap(
+                      STRING_ORDER_COMPARATOR, Map.Entry::getKey, entry -> null, mergeFunction)));
+    }
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(null, Function.identity(), STRINGIFY, mergeFunction));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(STRING_ORDER_COMPARATOR, null, STRINGIFY, mergeFunction));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            TreePMap.toTreePMap(STRING_ORDER_COMPARATOR, Function.identity(), null, mergeFunction));
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePMap.toTreePMap(STRING_ORDER_COMPARATOR, Function.identity(), STRINGIFY, null));
+  }
+
+  public void testValues() {
+    // TreePMap doesn't override AbstractMap.values(), so we just do a small sanity-check:
+
+    assertEquals(Arrays.asList(), new ArrayList<>(EMPTY.values()));
+    assertEquals(
+        Arrays.asList("1", "2", "10"),
+        new ArrayList<>(treePMapOf(STRINGIFY, 1, 2, 10).values()));
+  }
+
+  /**
+   * Holder of a NavigableMap that is known to behave as expected (typically an instance of TreeMap)
+   * and a corresponding TreePMap that we want to test against it. Useful for tests that involve a
+   * complicated set of verifications on each of multiple such subcases; such a test can build a
+   * list of appropriate subcases, then perform the verifications in a loop over that list.
+   */
+  private static final class Subcase {
+    final NavigableMap<Integer, String> expected;
+    final TreePMap<Integer, String> actual;
+
+    Subcase(final NavigableMap<Integer, String> expected, final TreePMap<Integer, String> actual) {
+      this.expected = expected;
+      this.actual = actual;
+    }
+  }
+
+  /**
+   * <p>Assert that actual has the expected state, in that it has the same mappings as expected, in
+   * the same order, and reports an equivalent comparator.</p>
+   *
+   * <p>This method is intended to validate the result of any method that produces a TreePMap.</p>
+   *
+   * <p>Background: a TreePMap instance has three pieces of state: a tree containing the mappings
+   * (which obviously has internal structure, but the TreePMap doesn't have to worry about that), a
+   * comparator that determines (and must match) the order of elements in the tree, and a boolean
+   * that controls whether the map's order is the same as the tree's or the opposite. To validate
+   * these three things, it's sufficient to verify that it has the right mappings in the right order
+   * (which confirms that the tree and the boolean are OK) and that it reports the right comparator
+   * (which, given that the boolean is OK, confirms that that the internal comparator is OK). (It's
+   * obviously not ideal to write a test based on our understanding of the inner workings of the
+   * class we're testing; but given the huge number of different producer method scenarios, we'd
+   * have a massive combinatorial explosion of different instances to test if we didn't cut it down
+   * in some way along these lines.)</p>
+   *
+   * <p>Caveat: if actual is empty or has only one mapping, then it's meaningless to talk about the
+   * order that its mappings are in. So any method that produces a TreePMap should have a test case
+   * for producing a TreePMap with more than one mapping (unless the method <em>never</em> produces
+   * a TreePMap with more than one mapping, in which case that doesn't matter).</p>
+   *
+   * @param expected
+   * @param actual
+   */
+  private static <V> void assertEquivalentState(
+      final SortedMap<Integer, V> expected,
+      final TreePMap<Integer, V> actual
+  ) {
+    assertSameSequence(expected.entrySet(), actual.entrySet());
+
+    assertEquivalentComparator(expected.comparator(), actual.comparator());
+  }
+
+  /** Same as {@link #assertEquivalentState(SortedMap, TreePMap)}, but for sets instead of maps. */
+  private static <V> void assertEquivalentState(
+      final SortedSet<Integer> expected,
+      final PSortedSet<Integer> actual
+  ) {
+    assertSameSequence(expected, actual);
+
+    assertEquivalentComparator(expected.comparator(), actual.comparator());
+  }
+
+  private static <E> void assertSameSequence(
+      final Iterable<E> expected,
+      final Iterable<E> actual
+  ) {
+    final ArrayList<E> expectedList = new ArrayList<>();
+    for (final E element : expected) {
+      expectedList.add(element);
+    }
+    final ArrayList<E> actualList = new ArrayList<>();
+    for (final E element : actual) {
+      actualList.add(element);
+    }
+    assertEquals(expectedList, actualList);
+  }
+
+  private static void assertEquivalentComparator(
+      final Comparator<? super Integer> expected,
+      final Comparator<? super Integer> actual
+  ) {
+    assertNotNull(actual);
+
+    // We only work with four orderings in this test -- the natural ordering (1 < 2 < 10), the
+    // reverse of that (10 < 2 < 1), a string-based ordering (1 < 10 < 2), and the reverse of that
+    // (2 < 10, 1) -- and we're not concerned that TreePMap might conjure up a different ordering
+    // or an invalid/inconsistent ordering; so all we need to check is that the two comparators sort
+    // { 1, 2, 10 } into the correct order:
+
+    final List<Integer> expectedList = Arrays.asList(2, 1, 10);
+    final List<Integer> actualList = Arrays.asList(2, 1, 10);
+
+    Collections.sort(expectedList, expected);
+    Collections.sort(actualList, actual);
+
+    assertEquals(expectedList, actualList);
+  }
+
+  private static void assertThrows(
+      final Class<? extends RuntimeException> exceptionClass,
+      final Runnable runnable
+  ) {
+    try {
+      runnable.run();
+
+      fail("Expected a [" + exceptionClass.getName() + "] to be thrown");
+    } catch (final RuntimeException re) {
+      if (! exceptionClass.isInstance(re)) {
+        final AssertionFailedError failure = new AssertionFailedError(
+            "Expected a [" + exceptionClass.getName() + "] to be thrown, instead got: " + re);
+        failure.initCause(re);
+        throw failure;
+      }
+    }
+  }
+
+  private static <K, V> Map.Entry<K, V> entryOf(final K key, final V value) {
+    return new AbstractMap.SimpleImmutableEntry<>(key, value);
+  }
+
+  private static Integer findSomeNonKey(final SortedMap<Integer, ?> map) {
+    int i = 0;
+    do {
+      if (! map.containsKey(i)) {
+        return i;
+      }
+    } while (++i != 0);
+    throw new AssertionFailedError("Map contains mappings for all integers??");
+  }
+
+  private static String randomString() {
+    return Integer.toString(RANDOM.nextInt());
+  }
+
+  private static <T> T serializeAndDeserialize(final T t) throws Exception {
+    final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    final ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+    objectOutputStream.writeObject(t);
+    objectOutputStream.flush();
+
+    final byte[] byteArray = byteArrayOutputStream.toByteArray();
+
+    final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+    final ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+
+    @SuppressWarnings("unchecked")
+    final T result = (T) objectInputStream.readObject();
+    assertEquals(-1, objectInputStream.read()); // assert that we read the whole thing
+
+    return result;
+  }
+
+  private static TreeMap<Integer, String> treeMapOf() {
+    return treeMapOf(STRINGIFY);
+  }
+
+  private static TreeMap<Integer, String> treeMapOf(
+      final Function<? super Integer, String> keyToValue,
+      final Integer... keys
+  ) {
+    final TreeMap<Integer, String> treeMap = new TreeMap<>();
+    for (final Integer key : keys) {
+      treeMap.put(key, keyToValue.apply(key));
+    }
+    return treeMap;
+  }
+
+  private static TreePMap<Integer, String> treePMapOf(
+      final Function<? super Integer, String> keyToValue,
+      final Integer... keys
+  ) {
+    TreePMap<Integer, String> treeMap = TreePMap.empty();
+    for (final Integer key : keys) {
+      treeMap = treeMap.plus(key, keyToValue.apply(key));
+    }
+    return treeMap;
+  }
+
+  private static TreePMap<Integer, String> treePMapOf(
+      final Comparator<? super Integer> comparator,
+      final Function<? super Integer, String> keyToValue,
+      final Integer... keys
+  ) {
+    TreePMap<Integer, String> treeMap = TreePMap.empty(comparator);
+    for (final Integer key : keys) {
+      treeMap = treeMap.plus(key, keyToValue.apply(key));
+    }
+    return treeMap;
+  }
+}

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -1,0 +1,1069 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections.tests;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.pcollections.TreePSet;
+import org.pcollections.tests.util.CompareInconsistentWithEquals;
+import org.pcollections.tests.util.StringOrderComparator;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.TestCase;
+
+public class TreePSetTest extends TestCase {
+  /**
+   * An empty TreePSet&lt;Integer&gt; using the natural ordering; useful in cases where type
+   * inference isn't clever enough to deduce the '&lt;Integer&gt;' on its own.
+   */
+  private static final TreePSet<Integer> EMPTY = TreePSet.empty();
+
+  private static final Random RANDOM = new Random();
+
+  private static final Comparator<Object> STRING_ORDER_COMPARATOR = StringOrderComparator.INSTANCE;
+
+  public void testComparator() {
+    // If don't specify a comparator, should get Comparator.naturalOrder():
+    assertEquivalentComparator(treeSetOf().comparator(), EMPTY.comparator());
+
+    // . . . and, descendingSet():
+    assertEquivalentComparator(
+        treeSetOf().descendingSet().comparator(),
+        EMPTY.descendingSet().comparator());
+
+    // If do specify a comparator, should get it:
+    assertSame(STRING_ORDER_COMPARATOR, TreePSet.empty(STRING_ORDER_COMPARATOR).comparator());
+
+    // . . . and, descendingSet():
+    assertEquivalentComparator(
+        STRING_ORDER_COMPARATOR.reversed(),
+        TreePSet.empty(STRING_ORDER_COMPARATOR).descendingSet().comparator());
+  }
+
+  public void testDescendingIterator() {
+    assertSameSequence(
+        treeSetOf()::descendingIterator,
+        EMPTY::descendingIterator);
+    assertSameSequence(
+        treeSetOf().descendingSet()::descendingIterator,
+        EMPTY.descendingSet()::descendingIterator);
+
+    assertSameSequence(
+        treeSetOf(1, 2, 3, 4, 5)::descendingIterator,
+        TreePSet.of(1, 2, 3, 4, 5)::descendingIterator);
+    assertSameSequence(
+        treeSetOf(1, 2, 3, 4, 5).descendingSet()::descendingIterator,
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet()::descendingIterator);
+
+    final TreePSet<Integer> set = TreePSet.of(1, 2, 3);
+    assertNotSame(set.descendingIterator(), set.descendingIterator());
+
+    final Iterator<Integer> iterator = set.descendingIterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+    }
+    assertThrows(NoSuchElementException.class, () -> iterator.next());
+  }
+
+  public void testDescendingSet() {
+    assertEquivalentState(
+        treeSetOf().descendingSet(),
+        EMPTY.descendingSet());
+    assertEquivalentState(
+        treeSetOf().descendingSet().descendingSet(),
+        EMPTY.descendingSet().descendingSet());
+
+    assertEquivalentState(
+        treeSetOf(1, 2, 3, 4).descendingSet(),
+        TreePSet.of(1, 2, 3, 4).descendingSet());
+    assertEquivalentState(
+        treeSetOf(1, 2, 3, 4).descendingSet().descendingSet(),
+        TreePSet.of(1, 2, 3, 4).descendingSet().descendingSet());
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4),
+        TreePSet.of(1, 2, 3, 4).descendingSet().descendingSet());
+
+    // Note: descendingSet() differs from all the other producer methods, from a testing standpoint,
+    // in that it sets a flag in the returned TreePSet that almost all other TreePSet methods have
+    // to take into account in order to behave correctly. So all of the other test-methods here also
+    // test different aspects of the set returned by descendingSet(), in order to test whatever
+    // method they're trying to test.
+  }
+
+  /**
+   * Test that TreePSet.equals(...) returns true for each of various sets that have the same size
+   * and elements, and that it returns false for each of various objects that are not such sets.
+   */
+  public void testEquals() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeSetOf(), EMPTY),
+        new Subcase(treeSetOf().descendingSet(), EMPTY.descendingSet()),
+        new Subcase(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5)),
+        new Subcase(
+            treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+            TreePSet.of(1, 2, 3, 4, 5).descendingSet()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableSet<Integer> expected = subcase.expected;
+      final TreePSet<Integer> actual = subcase.actual;
+
+      // must return false for anything other than a set:
+      assertFalse(actual.equals(null));
+      assertFalse(actual.equals(new Object()));
+      assertFalse(actual.equals((Object) "foo"));
+      assertFalse(actual.equals((Object) new ArrayList<>(actual)));
+
+      // must return true for a set with the same elements:
+      assertTrue(actual.equals(actual));
+      assertTrue(actual.equals(expected));
+      assertTrue(actual.equals((Object) new LinkedHashSet<>(expected)));
+      // . . . even if the iteration order is different:
+      assertTrue(actual.equals((Object) new HashSet<>(expected)));
+      assertTrue(actual.equals(actual.descendingSet()));
+      assertTrue(actual.equals(expected.descendingSet()));
+
+      // must return false for a set that's too small:
+      if (! actual.isEmpty()) {
+        final TreeSet<Integer> tooSmall = new TreeSet<>(expected);
+        tooSmall.pollFirst();
+        assertFalse(actual.equals((Object) tooSmall));
+      }
+
+      // must return false for a set that's too big:
+      {
+        final HashSet<Integer> tooBig = new HashSet<>(expected);
+        tooBig.add(findSomeNonElement(actual));
+        assertFalse(actual.equals((Object) tooBig));
+      }
+
+      // must return false for a set that has a wrong element:
+      if (! actual.isEmpty()) {
+        final TreeSet<Integer> wrong = new TreeSet<>(expected);
+        final Integer wrongElement = findSomeNonElement(wrong);
+        wrong.pollFirst();
+        wrong.add(wrongElement);
+        assertFalse(actual.equals((Object) wrong));
+      }
+    }
+  }
+
+  public void testEmpty() {
+    // the overload that takes no arguments (uses natural ordering):
+
+    assertEquivalentState(new TreeSet<>(), TreePSet.empty());
+
+    // the overload that takes a comparator:
+
+    assertEquivalentState(
+        new TreeSet<>(STRING_ORDER_COMPARATOR),
+        TreePSet.empty(STRING_ORDER_COMPARATOR));
+
+    assertThrows(NullPointerException.class, () -> TreePSet.empty(null));
+  }
+
+  public void testFrom() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    {
+      final List<Integer> collection = new ArrayList<>();
+      for (int i = 0; i < 20; ++i) {
+        collection.add(RANDOM.nextInt());
+      }
+
+      assertEquivalentState(new TreeSet<>(collection), TreePSet.from(collection));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(null));
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(Arrays.asList(3, null)));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final List<Integer> collection = new ArrayList<>();
+      for (int i = 0; i < 20; ++i) {
+        collection.add(RANDOM.nextInt());
+      }
+
+      final TreeSet<Integer> expected = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      expected.addAll(collection);
+
+      assertEquivalentState(
+          expected,
+          TreePSet.from(STRING_ORDER_COMPARATOR, collection));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(null, new ArrayList<>()));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePSet.from(STRING_ORDER_COMPARATOR, null));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePSet.from(STRING_ORDER_COMPARATOR, Arrays.asList(3, null)));
+  }
+
+  public void testFromSortedSet() {
+    // if SortedSet has null comparator, use natural-ordering comparator:
+    {
+      final TreeSet<Integer> expected = new TreeSet<>();
+      for (int i = 0; i < 20; ++i) {
+        expected.add(RANDOM.nextInt());
+      }
+
+      assertEquivalentState(expected, TreePSet.fromSortedSet(expected));
+    }
+
+    // if SortedSet has explicit comparator, use it:
+    {
+      final TreeSet<Integer> expected = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      for (int i = 0; i < 20; ++i) {
+        expected.add(RANDOM.nextInt());
+      }
+
+      assertEquivalentState(expected, TreePSet.fromSortedSet(expected));
+    }
+
+    // if SortedSet is actually already a TreePSet, just use it as-is:
+    {
+      TreePSet<Integer> expected = TreePSet.empty(STRING_ORDER_COMPARATOR);
+      for (int i = 0; i < 20; ++i) {
+        expected = expected.plus(RANDOM.nextInt());
+      }
+
+      assertSame(expected, TreePSet.fromSortedSet(expected));
+    }
+
+    // if SortedSet is actually null, complain:
+    assertThrows(NullPointerException.class, () -> TreePSet.fromSortedSet(null));
+
+    // if SortedSet contains null, complain:
+    {
+      final TreeSet<Integer> containsNull = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      containsNull.add(RANDOM.nextInt());
+      containsNull.add(null);
+
+      assertThrows(NullPointerException.class, () -> TreePSet.fromSortedSet(containsNull));
+    }
+  }
+
+  public void testHashCode() {
+    assertEquals(0, EMPTY.hashCode());
+    assertEquals(0, EMPTY.descendingSet().hashCode());
+
+    assertEquals(10, TreePSet.of(1, 2, 3, 4).hashCode());
+    assertEquals(10, TreePSet.of(1, 2, 3, 4).descendingSet().hashCode());
+  }
+
+  /**
+   * Verifies that, when comparison is not consistent with equals, that TreePSet honors the former
+   * rather than the latter.
+   */
+  public void testInconsistentWithEquals() {
+    final TreeSet<CompareInconsistentWithEquals> expected = new TreeSet<>();
+
+    TreePSet<CompareInconsistentWithEquals> actual = TreePSet.empty();
+
+    for (int i = 0 ; i < 20; ++i) {
+      final int randomEq1 = RANDOM.nextInt();
+      final int randomEq2 = RANDOM.nextInt();
+      final int randomComp1 = RANDOM.nextInt();
+      final int randomComp2 = RANDOM.nextInt();
+
+      final List<CompareInconsistentWithEquals> toAdd = Arrays.asList(
+          new CompareInconsistentWithEquals(randomEq1, randomComp1),
+          new CompareInconsistentWithEquals(randomEq1, randomComp2),
+          new CompareInconsistentWithEquals(randomEq2, randomComp1),
+          new CompareInconsistentWithEquals(randomEq2, randomComp2));
+
+      expected.addAll(toAdd);
+      actual = actual.plusAll(toAdd);
+    }
+
+    assertEquals(expected.size(), actual.size());
+
+    final Iterator<CompareInconsistentWithEquals> actualIterator = actual.iterator();
+    for (final CompareInconsistentWithEquals expectedElement : expected) {
+      assertSame(expectedElement, actualIterator.next());
+    }
+  }
+
+  public void testIsEmpty() {
+    assertTrue(EMPTY.isEmpty());
+    assertTrue(EMPTY.descendingSet().isEmpty());
+
+    assertFalse(TreePSet.of(1, 2, 3, 4).isEmpty());
+    assertFalse(TreePSet.of(1, 2, 3, 4).descendingSet().isEmpty());
+  }
+
+  public void testIterator() {
+    assertEquivalentState(treeSetOf(), EMPTY);
+    assertEquivalentState(treeSetOf().descendingSet(), EMPTY.descendingSet());
+
+    assertEquivalentState(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5));
+    assertEquivalentState(
+        treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet());
+
+    final TreePSet<Integer> set = TreePSet.of(1, 2, 3);
+    assertNotSame(set.iterator(), set.iterator());
+
+    final Iterator<Integer> iterator = set.iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+    }
+    assertThrows(NoSuchElementException.class, () -> iterator.next());
+  }
+
+  /**
+   * This test ensures that we cover all the different cases in KVTree.join (meaning, all the
+   * different relative heights of left.left, left.right, right.left, and right.right that have to
+   * be handled in different ways), because some of them have low probability of occurring randomly.
+   */
+  public void testKVTreeJoin() {
+    /** a perfect tree of height 3 */
+    final TreePSet<Integer> oneToSeven = TreePSet.of(1, 2, 3, 4, 5, 6, 7);
+    /** a perfect tree of height 4 */
+    final TreePSet<Integer> oneToFifteen =
+        TreePSet.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+    // case where left.height < right.height - 2:
+    assertEquivalentState(treeSetOf(8, 9, 10, 11, 12, 13, 14, 15), oneToFifteen.tailSet(8, true));
+
+    // case where left.height == right.height - 2 and right.left.height <= right.right.height:
+    assertEquivalentState(treeSetOf(4, 6, 7), oneToSeven.minus(5).tailSet(4, true));
+
+    // case where left.height == right.height - 2 and right.left.height > right.right.height:
+    assertEquivalentState(treeSetOf(4, 5, 6), oneToSeven.minus(7).tailSet(4, true));
+
+    // skip case where |left.height - right.height| <= 1 -- this happens naturally all the time
+    // (including in this method), no special coverage needed
+
+    // case where left.height == right.height + 2 and left.left.height < left.right.height:
+    assertEquivalentState(treeSetOf(2, 3, 4), oneToSeven.minus(1).headSet(4, true));
+
+    // case where left.height == right.height + 2 and left.left.height >= left.right.height:
+    assertEquivalentState(treeSetOf(1, 2, 4), oneToSeven.minus(3).headSet(4, true));
+
+    // case where left.height > right.height + 2:
+    assertEquivalentState(treeSetOf(1, 2, 3, 4, 5, 6, 7, 8), oneToFifteen.headSet(8, true));
+  }
+
+  /** Perform a few simple validations on a largish random set (just as a sanity-check). */
+  public void testLargishRandomSet() {
+    final TreeSet<Integer> expected = new TreeSet<>();
+    TreePSet<Integer> actual = TreePSet.empty();
+
+    for (int i = 0; i < 20_000; ++i) {
+      final Integer intToAdd = RANDOM.nextInt();
+      expected.add(intToAdd);
+      actual = actual.plus(intToAdd);
+    }
+
+    assertEquivalentState(expected, actual);
+    assertEquivalentState(expected.descendingSet(), actual.descendingSet());
+
+    assertTrue(actual.containsAll(expected));
+
+    {
+      final int a = RANDOM.nextInt();
+      final int b = RANDOM.nextInt();
+
+      final int from = Math.min(a, b);
+      final int to = Math.max(a, b);
+
+      assertEquivalentState(expected.subSet(from, to), actual.subSet(from, to));
+      assertEquivalentState(
+          expected.descendingSet().subSet(to, from),
+          actual.descendingSet().subSet(to, from));
+    }
+  }
+
+  public void testMinusAll() {
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.minusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        EMPTY,
+        TreePSet.of(1, 2, 3, 4, 5).minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        TreePSet.of(1, 3, 5),
+        TreePSet.of(1, 2, 3, 4, 5).minusAll(Arrays.asList(0, 2, 4, 6)));
+
+    assertEquivalentState(
+        EMPTY.descendingSet(),
+        EMPTY.descendingSet().minusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        EMPTY.descendingSet(),
+        EMPTY.descendingSet().minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        EMPTY.descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet().minusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        TreePSet.of(1, 3, 5).descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet().minusAll(Arrays.asList(0, 2, 4, 6)));
+
+    assertThrows(NullPointerException.class, () -> EMPTY.minusAll(null));
+    assertThrows(NullPointerException.class, () -> EMPTY.minusAll(Arrays.asList(0, null)));
+  }
+
+  public void testMinusFirst() {
+    assertThrows(NoSuchElementException.class, () -> EMPTY.minusFirst());
+
+    assertEquivalentState(TreePSet.of(2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5).minusFirst());
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4).descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet().minusFirst());
+  }
+
+  public void testMinusLast() {
+    assertThrows(NoSuchElementException.class, () -> EMPTY.minusLast());
+
+    assertEquivalentState(TreePSet.of(1, 2, 3, 4), TreePSet.of(1, 2, 3, 4, 5).minusLast());
+
+    assertEquivalentState(
+        TreePSet.of(2, 3, 4, 5).descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet().minusLast());
+  }
+
+  /**
+   * Test that add(...), addAll(...), clear(), pollFirst(), pollLast(), remove(...), removeAll(...),
+   * removeIf(...), and retainAll(...) all throw UnsupportedOperationException.
+   */
+  @SuppressWarnings("deprecation")
+  public void testMutators() {
+    final TreePSet<Integer> set = TreePSet.of(1, 2, 3, 4);
+
+    assertThrows(UnsupportedOperationException.class, () -> set.add(10));
+    assertThrows(UnsupportedOperationException.class, () -> set.addAll(Collections.emptyList()));
+    assertThrows(UnsupportedOperationException.class, () -> set.clear());
+    assertThrows(UnsupportedOperationException.class, () -> set.pollFirst());
+    assertThrows(UnsupportedOperationException.class, () -> set.pollLast());
+    assertThrows(UnsupportedOperationException.class, () -> set.remove(10));
+    assertThrows(UnsupportedOperationException.class, () -> set.removeAll(Collections.emptyList()));
+    assertThrows(UnsupportedOperationException.class, () -> set.removeIf(o -> false));
+    assertThrows(UnsupportedOperationException.class, () -> set.retainAll(Collections.emptyList()));
+  }
+
+  /** Perform a few simple validations on a set of non-integers (just as a sanity-check). */
+  public void testNonIntegerSet() {
+    final TreeSet<Double> expected = new TreeSet<>();
+    TreePSet<Double> actual = TreePSet.empty();
+
+    for (int i = 0; i < 100; ++i) {
+      final Double doubleToAdd = RANDOM.nextDouble();
+      expected.add(doubleToAdd);
+      actual = actual.plus(doubleToAdd);
+    }
+
+    assertSameSequence(expected, actual);
+    assertSameSequence(expected.descendingSet(), actual.descendingSet());
+
+    assertTrue(actual.containsAll(expected));
+
+    {
+      final double a = RANDOM.nextDouble();
+      final double b = RANDOM.nextDouble();
+
+      final double from = Math.min(a, b);
+      final double to = Math.max(a, b);
+
+      assertSameSequence(expected.subSet(from, to), actual.subSet(from, to));
+      assertSameSequence(
+          expected.descendingSet().subSet(to, from),
+          actual.descendingSet().subSet(to, from));
+    }
+  }
+
+  public void testOf() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    assertEquivalentState(
+        treeSetOf(),
+        EMPTY);
+
+    assertEquivalentState(
+        treeSetOf(1),
+        TreePSet.of(1));
+
+    assertEquivalentState(
+        treeSetOf(1, 3, 5, 2, 4),
+        TreePSet.of(1, 3, 5, 2, 4));
+
+    assertEquivalentState(
+        treeSetOf(new Integer[] { 1, 3, 5, 2, 4 }),
+        TreePSet.of(new Integer[] { 1, 3, 5, 2, 4 }));
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(null));
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(Arrays.asList(3, null)));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final List<Integer> collection = new ArrayList<>();
+      for (int i = 0; i < 20; ++i) {
+        collection.add(RANDOM.nextInt());
+      }
+
+      final TreeSet<Integer> expected = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      expected.addAll(collection);
+
+      assertEquivalentState(
+          expected,
+          TreePSet.from(STRING_ORDER_COMPARATOR, collection));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePSet.from(null, new ArrayList<>()));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePSet.from(STRING_ORDER_COMPARATOR, null));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePSet.from(STRING_ORDER_COMPARATOR, Arrays.asList(3, null)));
+  }
+
+  public void testPlusAndMinus() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeSetOf(), EMPTY),
+        new Subcase(treeSetOf().descendingSet(), EMPTY.descendingSet()),
+        new Subcase(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5)),
+        new Subcase(
+            treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+            TreePSet.of(1, 2, 3, 4, 5).descendingSet()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableSet<Integer> expected = subcase.expected;
+      final TreePSet<Integer> actual = subcase.actual;
+
+      final ArrayList<Integer> valuesToTest = new ArrayList<>();
+      valuesToTest.add(0);
+      for (final int i : expected) {
+        valuesToTest.add(i - 1);
+        valuesToTest.add(i);
+        valuesToTest.add(i + 1);
+      }
+
+      for (final Integer value : valuesToTest) {
+        final boolean wasPresent = expected.contains(value);
+
+        expected.add(value);
+        assertEquivalentState(expected, actual.plus(value));
+
+        expected.remove(value);
+        assertEquivalentState(expected, actual.minus(value));
+
+        if (wasPresent) {
+          expected.add(value);
+        }
+      }
+
+      assertThrows(NullPointerException.class, () -> actual.plus(null));
+      assertThrows(NullPointerException.class, () -> actual.minus(null));
+    }
+  }
+
+  public void testPlusAll() {
+    assertEquivalentState(
+        EMPTY,
+        EMPTY.plusAll(Arrays.asList()));
+    assertEquivalentState(
+        EMPTY.descendingSet(),
+        EMPTY.descendingSet().plusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5),
+        EMPTY.plusAll(Arrays.asList(1, 2, 3, 4, 5)));
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet(),
+        EMPTY.descendingSet().plusAll(Arrays.asList(1, 2, 3, 4, 5)));
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5),
+        TreePSet.of(1, 2, 3, 4, 5).plusAll(Arrays.asList()));
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet(),
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet().plusAll(Arrays.asList()));
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5),
+        TreePSet.of(1, 3, 5).plusAll(Arrays.asList(2, 3, 4)));
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4, 5).descendingSet(),
+        TreePSet.of(1, 3, 5).descendingSet().plusAll(Arrays.asList(2, 3, 4)));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> EMPTY.plusAll(null));
+    assertThrows(
+        NullPointerException.class,
+        () -> EMPTY.plusAll(Arrays.asList(0, null)));
+  }
+
+  /**
+   * Test headSet(), subSet(), and tailSet() -- both the overloads with the 'isInclusive'
+   * parameter(s) and the overloads without.
+   */
+  public void testRanges() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeSetOf(), EMPTY),
+        new Subcase(treeSetOf().descendingSet(), EMPTY.descendingSet()),
+        new Subcase(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5)),
+        new Subcase(
+            treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+            TreePSet.of(1, 2, 3, 4, 5).descendingSet()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableSet<Integer> expected = subcase.expected;
+      final TreePSet<Integer> actual = subcase.actual;
+
+      final ArrayList<Integer> bounds = new ArrayList<>();
+      bounds.add(0);
+      for (final int i : expected) {
+        bounds.add(i - 1);
+        bounds.add(i);
+        bounds.add(i + 1);
+      }
+
+      for (final int to : bounds) {
+        assertEquivalentState(expected.headSet(to), actual.headSet(to));
+        assertEquivalentState(expected.headSet(to, true), actual.headSet(to, true));
+        assertEquivalentState(expected.headSet(to, false), actual.headSet(to, false));
+
+        for (final int from : bounds) {
+          if (actual.comparator().compare(from, to) <= 0) {
+            assertEquivalentState(
+                expected.subSet(from, to),
+                actual.subSet(from, to));
+            assertEquivalentState(
+                expected.subSet(from, true, to, true),
+                actual.subSet(from, true, to, true));
+            assertEquivalentState(
+                expected.subSet(from, true, to, false),
+                actual.subSet(from, true, to, false));
+            assertEquivalentState(
+                expected.subSet(from, false, to, true),
+                actual.subSet(from, false, to, true));
+            assertEquivalentState(
+                expected.subSet(from, false, to, false),
+                actual.subSet(from, false, to, false));
+          } else {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> actual.subSet(from, to));
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> actual.subSet(from, true, to, true));
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> actual.subSet(from, true, to, false));
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> actual.subSet(from, false, to, true));
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> actual.subSet(from, false, to, false));
+          }
+        }
+      }
+
+      for (final int from : bounds) {
+        assertEquivalentState(expected.tailSet(from), actual.tailSet(from));
+        assertEquivalentState(expected.tailSet(from, true), actual.tailSet(from, true));
+        assertEquivalentState(expected.tailSet(from, false), actual.tailSet(from, false));
+      }
+
+      assertThrows(NullPointerException.class, () -> actual.headSet(null));
+      assertThrows(NullPointerException.class, () -> actual.headSet(null, true));
+      assertThrows(NullPointerException.class, () -> actual.subSet(null, 0));
+      assertThrows(NullPointerException.class, () -> actual.subSet(null, true, 0, true));
+      assertThrows(NullPointerException.class, () -> actual.subSet(0, null));
+      assertThrows(NullPointerException.class, () -> actual.subSet(0, true, null, true));
+      assertThrows(NullPointerException.class, () -> actual.tailSet(null));
+      assertThrows(NullPointerException.class, () -> actual.tailSet(null, true));
+    }
+  }
+
+  /**
+   * Test ceiling(...), contains(...), containsAll(...), first(), floor(...), higher(...), last(),
+   * and lower(...), by validating that they give the same result for a TreePSet as for a TreeSet.
+   */
+  public void testSearchers() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeSetOf(), EMPTY),
+        new Subcase(treeSetOf().descendingSet(), EMPTY.descendingSet()),
+        new Subcase(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5)),
+        new Subcase(
+            treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+            TreePSet.of(1, 2, 3, 4, 5).descendingSet()),
+        new Subcase(treeSetOf(1, 3, 5, 7, 9), TreePSet.of(1, 3, 5, 7, 9)),
+        new Subcase(
+            treeSetOf(1, 3, 5, 7, 9).descendingSet(),
+            TreePSet.of(1, 3, 5, 7, 9).descendingSet()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableSet<Integer> expected = subcase.expected;
+      final TreePSet<Integer> actual = subcase.actual;
+
+      // ensure that we have an element to test even if expected is empty:
+      final Iterable<Integer> elementsToTest = expected.isEmpty() ? Arrays.asList(0) : expected;
+
+      for (final int element : elementsToTest) {
+        for (final int arg : new int[] { element - 1, element, element + 1 }) {
+          assertEquals(expected.ceiling(arg), actual.ceiling(arg));
+          assertEquals(expected.contains(arg), actual.contains(arg));
+          assertEquals(expected.floor(arg), actual.floor(arg));
+          assertEquals(expected.higher(arg), actual.higher(arg));
+          assertEquals(expected.lower(arg), actual.lower(arg));
+        }
+      }
+
+      assertTrue(actual.containsAll(expected));
+      assertFalse(actual.containsAll(Arrays.asList(findSomeNonElement(expected))));
+
+      if (expected.isEmpty()) {
+        assertThrows(NoSuchElementException.class, actual::first);
+        assertThrows(NoSuchElementException.class, actual::last);
+      } else {
+        assertEquals(expected.first(), actual.first());
+        assertEquals(expected.last(), actual.last());
+      }
+
+      assertThrows(NullPointerException.class, () -> actual.ceiling(null));
+      assertThrows(NullPointerException.class, () -> actual.contains(null));
+      assertThrows(NullPointerException.class, () -> actual.floor(null));
+      assertThrows(NullPointerException.class, () -> actual.higher(null));
+      assertThrows(NullPointerException.class, () -> actual.lower(null));
+    }
+  }
+
+  public void testSerializeAndDeserialize() throws Exception {
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4),
+        serializeAndDeserialize(TreePSet.of(1, 2, 3, 4)));
+
+    assertEquivalentState(
+        TreePSet.of(1, 2, 3, 4).descendingSet(),
+        serializeAndDeserialize(TreePSet.of(1, 2, 3, 4).descendingSet()));
+
+    assertEquivalentState(
+        TreePSet.of(STRING_ORDER_COMPARATOR, 1, 2, 3, 4),
+        serializeAndDeserialize(TreePSet.of(STRING_ORDER_COMPARATOR, 1, 2, 3, 4)));
+
+    assertEquivalentState(
+        TreePSet.of(STRING_ORDER_COMPARATOR, 1, 2, 3, 4).descendingSet(),
+        serializeAndDeserialize(TreePSet.of(STRING_ORDER_COMPARATOR, 1, 2, 3, 4).descendingSet()));
+  }
+
+  public void testSingleton() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    assertEquivalentState(new TreeSet<>(Arrays.asList(3)), TreePSet.singleton(3));
+
+    assertThrows(NullPointerException.class, () -> TreePSet.singleton(null));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final TreeSet<Integer> expected = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      expected.add(17);
+
+      assertEquivalentState(expected, TreePSet.singleton(STRING_ORDER_COMPARATOR, 17));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePSet.singleton(null, 3));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> TreePSet.singleton(STRING_ORDER_COMPARATOR, null));
+  }
+
+  public void testSize() {
+    assertEquals(0, EMPTY.size());
+    assertEquals(0, EMPTY.descendingSet().size());
+
+    assertEquals(4, TreePSet.of(1, 2, 3, 4).size());
+    assertEquals(4, TreePSet.of(1, 2, 3, 4).descendingSet().size());
+  }
+
+  /**
+   * Test toArray() -- both the overload that takes an array parameter, and the one that does not.
+   */
+  public void testToArray() {
+    final List<Subcase> subcases = Arrays.asList(
+        new Subcase(treeSetOf(), EMPTY),
+        new Subcase(treeSetOf().descendingSet(), EMPTY.descendingSet()),
+        new Subcase(treeSetOf(1, 2, 3, 4, 5), TreePSet.of(1, 2, 3, 4, 5)),
+        new Subcase(
+            treeSetOf(1, 2, 3, 4, 5).descendingSet(),
+            TreePSet.of(1, 2, 3, 4, 5).descendingSet()));
+
+    for (final Subcase subcase : subcases) {
+      final NavigableSet<Integer> expected = subcase.expected;
+      final TreePSet<Integer> actual = subcase.actual;
+
+      // no arg:
+      assertEquals(Arrays.asList(expected.toArray()), Arrays.asList(actual.toArray()));
+
+      // arg with exactly the right size:
+      {
+        final Integer[] expectedArr = new Integer[expected.size()];
+        expected.toArray(expectedArr);
+        final Integer[] actualArr = new Integer[expected.size()];
+        assertSame(actualArr, actual.toArray(actualArr));
+        assertEquals(Arrays.asList(expectedArr), Arrays.asList(actualArr));
+      }
+
+      // arg that's too small:
+      if (! expected.isEmpty()) {
+        final Integer[] tooSmall = new Integer[expected.size() - 1];
+        final Integer[] expectedArr = expected.toArray(tooSmall);
+        final Integer[] actualArr = actual.toArray(tooSmall);
+        assertEquals(Arrays.asList(expectedArr), Arrays.asList(actualArr));
+      }
+
+      // arg that's too big:
+      {
+        final Integer[] expectedArr = new Integer[expected.size() + 10];
+        Arrays.fill(expectedArr, 20);
+        expected.toArray(expectedArr);
+        final Integer[] actualArr = new Integer[expected.size() + 10];
+        Arrays.fill(actualArr, 20);
+        assertSame(actualArr, actual.toArray(actualArr));
+        assertEquals(Arrays.asList(expectedArr), Arrays.asList(actualArr));
+      }
+
+      // arg that's a supertype:
+      assertEquals(Number.class, actual.toArray(new Number[0]).getClass().getComponentType());
+    }
+  }
+
+  public void testToString() {
+    // empty set:
+    assertEquals("[]", EMPTY.toString());
+    assertEquals("[]", EMPTY.descendingSet().toString());
+
+    // singleton set -- no commas:
+    assertEquals("[1]", TreePSet.of(1).toString());
+    assertEquals("[1]", TreePSet.of(1).descendingSet().toString());
+
+    // set with multiple elements -- separated with comma + space, and order matters:
+    assertEquals("[1, 2, 3, 4, 5]", TreePSet.of(1, 2, 3, 4, 5).toString());
+    assertEquals("[5, 4, 3, 2, 1]", TreePSet.of(1, 2, 3, 4, 5).descendingSet().toString());
+  }
+
+  public void testToTreePSet() {
+    // the overload that doesn't take an explicit comparator (uses natural ordering):
+
+    {
+      final List<Integer> collection = new ArrayList<>();
+      for (int i = 0; i < 20; ++i) {
+        collection.add(RANDOM.nextInt());
+      }
+
+      final TreeSet<Integer> expected = new TreeSet<>(collection);
+
+      assertEquivalentState(expected, collection.stream().collect(TreePSet.toTreePSet()));
+    }
+
+    assertThrows(
+        NullPointerException.class,
+        () -> Arrays.asList(3, null).stream().collect(TreePSet.toTreePSet()));
+
+    // the overload that does take an explicit comparator:
+
+    {
+      final List<Integer> collection = new ArrayList<>();
+      for (int i = 0; i < 20; ++i) {
+        collection.add(RANDOM.nextInt());
+      }
+
+      final TreeSet<Integer> expected = new TreeSet<>(STRING_ORDER_COMPARATOR);
+      expected.addAll(collection);
+
+      assertEquivalentState(
+          expected,
+          collection.stream().collect(TreePSet.toTreePSet(STRING_ORDER_COMPARATOR)));
+    }
+
+    assertThrows(NullPointerException.class, () -> TreePSet.toTreePSet(null));
+
+    assertThrows(
+        NullPointerException.class,
+        () -> Arrays.asList(3, null).stream().collect(TreePSet.toTreePSet(STRING_ORDER_COMPARATOR)));
+  }
+
+  /**
+   * Holder of a NavigableSet that is known to behave as expected (typically an instance of TreeSet)
+   * and a corresponding TreePSet that we want to test against it. Useful for tests that involve a
+   * complicated set of verifications on each of multiple such subcases; such a test can build a
+   * list of appropriate subcases, then perform the verifications in a loop over that list.
+   */
+  private static final class Subcase {
+    final NavigableSet<Integer> expected;
+    final TreePSet<Integer> actual;
+
+    Subcase(final NavigableSet<Integer> expected, final TreePSet<Integer> actual) {
+      this.expected = expected;
+      this.actual = actual;
+    }
+  }
+
+  /**
+   * <p>Assert that actual has the expected state, in that it has the same elements as expected, in
+   * the same order, and reports an equivalent comparator.</p>
+   *
+   * <p>This method is intended to validate the result of any method that produces a TreePSet.</p>
+   *
+   * <p>Background: a TreePSet instance has three pieces of state: a tree containing the elements
+   * (which obviously has internal structure, but the TreePSet doesn't have to worry about that), a
+   * comparator that determines (and must match) the order of elements in the tree, and a boolean
+   * that controls whether the set's order is the same as the tree's or the opposite. To validate
+   * these three things, it's sufficient to verify that it has the right elements in the right order
+   * (which confirms that the tree and the boolean are OK) and that it reports the right comparator
+   * (which, given that the boolean is OK, confirms that that the internal comparator is OK). (It's
+   * obviously not ideal to write a test based on our understanding of the inner workings of the
+   * class we're testing; but given the huge number of different producer method scenarios, we'd
+   * have a massive combinatorial explosion of different instances to test if we didn't cut it down
+   * in some way along these lines.)</p>
+   *
+   * <p>Caveat: if actual is empty or has only one element, then it's meaningless to talk about the
+   * order that its elements are in. So any method that produces a TreePSet should have a test case
+   * for producing a TreePSet with more than one element (unless the method <em>never</em> produces
+   * a TreePSet with more than one element, in which case that doesn't matter).</p>
+   *
+   * @param expected
+   * @param actual
+   */
+  private static void assertEquivalentState(
+      final SortedSet<Integer> expected,
+      final TreePSet<Integer> actual
+  ) {
+    assertSameSequence(expected, actual);
+
+    assertEquivalentComparator(expected.comparator(), actual.comparator());
+  }
+
+  private static <E> void assertSameSequence(
+      final Iterable<E> expected,
+      final Iterable<E> actual
+  ) {
+    final ArrayList<E> expectedList = new ArrayList<>();
+    for (final E element : expected) {
+      expectedList.add(element);
+    }
+    final ArrayList<E> actualList = new ArrayList<>();
+    for (final E element : actual) {
+      actualList.add(element);
+    }
+    assertEquals(expectedList, actualList);
+  }
+
+  private static void assertEquivalentComparator(
+      final Comparator<? super Integer> expected,
+      final Comparator<? super Integer> actual
+  ) {
+    assertNotNull(actual);
+
+    // We only work with five orderings in this test -- the natural ordering (1 < 2 < 10), the
+    // reverse of that (10 < 2 < 1), a string-based ordering (1 < 10 < 2), the reverse of that
+    // (2 < 10 < 1), and an ordering that treats all values as equivalent (1 = 2 = 10) -- and we're
+    // not concerned that TreePSet might conjure up a different ordering or an invalid/inconsistent
+    // ordering; so all we need to check is that the two comparators sort { 2, 1, 10 } into the
+    // same order:
+
+    final List<Integer> expectedList = Arrays.asList(2, 1, 10);
+    final List<Integer> actualList = Arrays.asList(2, 1, 10);
+
+    Collections.sort(expectedList, expected);
+    Collections.sort(actualList, actual);
+
+    assertEquals(expectedList, actualList);
+  }
+
+  private static void assertThrows(
+      final Class<? extends RuntimeException> exceptionClass,
+      final Runnable runnable
+  ) {
+    try {
+      runnable.run();
+
+      fail("Expected a [" + exceptionClass.getName() + "] to be thrown");
+    } catch (final RuntimeException re) {
+      if (! exceptionClass.isInstance(re)) {
+        final AssertionFailedError failure = new AssertionFailedError(
+            "Expected a [" + exceptionClass.getName() + "] to be thrown, instead got: " + re);
+        failure.initCause(re);
+        throw failure;
+      }
+    }
+  }
+
+  private static Integer findSomeNonElement(final SortedSet<Integer> set) {
+    int i = 0;
+    do {
+      if (! set.contains(i)) {
+        return i;
+      }
+    } while (++i != 0);
+    throw new AssertionFailedError("Set contains all integers??");
+  }
+
+  private static <T> T serializeAndDeserialize(final T t) throws Exception {
+    final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    final ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+    objectOutputStream.writeObject(t);
+    objectOutputStream.flush();
+
+    final byte[] byteArray = byteArrayOutputStream.toByteArray();
+
+    final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArray);
+    final ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+
+    @SuppressWarnings("unchecked")
+    final T result = (T) objectInputStream.readObject();
+    assertEquals(-1, objectInputStream.read()); // assert that we read the whole thing
+
+    return result;
+  }
+
+  private static TreeSet<Integer> treeSetOf(final Integer... elements) {
+    return new TreeSet<>(Arrays.asList(elements));
+  }
+}

--- a/src/test/java/org/pcollections/tests/util/CompareInconsistentWithEquals.java
+++ b/src/test/java/org/pcollections/tests/util/CompareInconsistentWithEquals.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections.tests.util;
+
+/**
+ * A class with a natural ordering that is inconsistent with equals; instances have a distinct 'eq'
+ * field and 'comp' field, where two instances are equal according to {@link #equals(Object)} if
+ * they have the same value of 'eq', but compare equal according to
+ * {@link #compareTo(CompareInconsistentWithEquals)} if they have the same value of 'comp'.
+ * (Intended for use by TreePSetTest and TreePMapTest in verifying correct handling when an ordering
+ * is inconsistent with equals.)
+ *
+ * @author Ran Ari-Gur
+ */
+public final class CompareInconsistentWithEquals
+  implements Comparable<CompareInconsistentWithEquals>
+{
+  private final int eq;
+  private final int comp;
+
+  /**
+   * @param eq
+   *          the value to control whether two instances are equal according to
+   *          {@link #equals(Object)}
+   * @param comp
+   *          the value to control the ordering of two instances according to
+   *          {@link #compareTo(CompareInconsistentWithEquals)}, and hence whether two instances
+   *          compare equal according to their natural ordering
+   */
+  public CompareInconsistentWithEquals(final int eq, final int comp) {
+    this.eq = eq;
+    this.comp = comp;
+  }
+
+  @Override
+  public int compareTo(final CompareInconsistentWithEquals that) {
+    return Integer.compare(this.comp, that.comp);
+  }
+
+  @Override
+  public boolean equals(final Object that) {
+    return that instanceof CompareInconsistentWithEquals
+        && this.eq == ((CompareInconsistentWithEquals)that).eq;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("CompareInconsistentWithEquals(%s, %s)", eq, comp);
+  }
+}

--- a/src/test/java/org/pcollections/tests/util/StringOrderComparator.java
+++ b/src/test/java/org/pcollections/tests/util/StringOrderComparator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Ran Ari-Gur. All rights reserved.
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+package org.pcollections.tests.util;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * A comparator that compares objects by their string values; for example, it reports that
+ * 1 is less than 10 and 10 is less than 2, because in fact "1" is less than "10" and "10" is less
+ * than "2". This is not consistent with equals over all objects, but is consistent with equals over
+ * restricted domains, such as instances of java.lang.Integer, or instances of java.lang.Double.
+ * (Intended for use by TreePSetTest and TreePMapTest in verifying correct handling when a custom
+ * comparator is used.)
+ *
+ * @author Ran Ari-Gur
+ */
+public enum StringOrderComparator implements Comparator<Object>, Serializable {
+  INSTANCE;
+
+  @Override
+  public int compare(final Object a, final Object b) {
+    return String.valueOf(a).compareTo(String.valueOf(b));
+  }
+}


### PR DESCRIPTION
This pull request addresses issue #20 ([SortedSet/TreeSet alternative?](https://github.com/hrldcpr/pcollections/issues/20)), by adding the following:

- new interface PSortedMap extending both PMap and java.util.NavigableMap
- new interface PSortedSet extending both PSet and java.util.NavigableSet
- new classes TreePMap and TreePSet implementing those interfaces (respectively)
- a few new classes that support the implementation of TreePMap and TreePSet
- corresponding unit-tests and documentation
- new methods Empty.sortedMap and Empty.sortedSet

I realize this is kind of huge; if you're on board with the general approach, but want to go back-and-forth with separate pull requests for separate pieces, I'm open to that.