### PR TITLE
Throw UnsupportedOperationException from HashPMap, IntTreePMap, and OrderedPSet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ repositories {
 
 dependencies {
     // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
-    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testCompile 'org.junit.vintage:junit-vintage-engine:5.1.0'
     testCompile 'org.assertj:assertj-core:3.9.1'
 }

--- a/src/main/java/org/pcollections/HashPMap.java
+++ b/src/main/java/org/pcollections/HashPMap.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * @param <K>
  * @param <V>
  */
-public final class HashPMap<K, V> extends AbstractMap<K, V> implements PMap<K, V>, Serializable {
+public final class HashPMap<K, V> extends AbstractUnmodifiableMap<K, V> implements PMap<K, V>, Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/pcollections/IntTreePMap.java
+++ b/src/main/java/org/pcollections/IntTreePMap.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * @author harold
  * @param <V>
  */
-public final class IntTreePMap<V> extends AbstractMap<Integer, V>
+public final class IntTreePMap<V> extends AbstractUnmodifiableMap<Integer, V>
     implements PMap<Integer, V>, Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/org/pcollections/OrderedPSet.java
+++ b/src/main/java/org/pcollections/OrderedPSet.java
@@ -11,7 +11,7 @@ import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
 
-public class OrderedPSet<E> extends AbstractSet<E> implements POrderedSet<E>, Serializable {
+public class OrderedPSet<E> extends AbstractUnmodifiableSet<E> implements POrderedSet<E>, Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/src/test/java/org/pcollections/tests/ConsPStackTest.java
+++ b/src/test/java/org/pcollections/tests/ConsPStackTest.java
@@ -22,7 +22,7 @@ public class ConsPStackTest extends TestCase {
   public void testRandomlyAgainstJavaList() {
     PStack<Integer> pstack = ConsPStack.empty();
     List<Integer> list = new LinkedList<Integer>();
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 1000; i++) {
       if (pstack.size() == 0 || r.nextBoolean()) { // add
         if (r.nextBoolean()) { // append

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -14,6 +14,8 @@ import junit.framework.TestCase;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
 
+import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
+
 public class HashPMapTest extends TestCase {
 
   /** Compares the behavior of java.util.HashMap to the behavior of HashTreePMap. */
@@ -90,5 +92,12 @@ public class HashPMapTest extends TestCase {
   public void testSingleton() {
     UtilityTest.assertEqualsAndHash(
         HashTreePMap.empty().plus(10, "test"), HashTreePMap.singleton(10, "test"));
+  }
+
+  public void testUnmodifiable() {
+    assertMapMutatorsThrow(
+        HashTreePMap.singleton("key1", "value1"),
+        "key2", "value2"
+    );
   }
 }

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -20,7 +20,7 @@ public class HashPMapTest extends TestCase {
   public void testRandomlyAgainstJavaMap() {
     PMap<Integer, Integer> pmap = HashTreePMap.empty();
     Map<Integer, Integer> map = new HashMap<Integer, Integer>();
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 10000; i++) {
       if (pmap.size() == 0 || r.nextBoolean()) { // add
         int k = r.nextInt(), v = r.nextInt();

--- a/src/test/java/org/pcollections/tests/IntTreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/IntTreePMapTest.java
@@ -20,7 +20,7 @@ public class IntTreePMapTest extends TestCase {
   public void testRandomlyAgainstJavaMap() {
     PMap<Integer, Integer> pmap = IntTreePMap.empty();
     Map<Integer, Integer> map = new HashMap<Integer, Integer>();
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 10000; i++) {
       if (pmap.size() == 0 || r.nextBoolean()) { // add
         int k = r.nextInt(), v = r.nextInt();

--- a/src/test/java/org/pcollections/tests/IntTreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/IntTreePMapTest.java
@@ -14,6 +14,8 @@ import junit.framework.TestCase;
 import org.pcollections.IntTreePMap;
 import org.pcollections.PMap;
 
+import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
+
 public class IntTreePMapTest extends TestCase {
 
   /** Compares the behavior of java.util.HashMap to the behavior of IntTreePMap. */
@@ -90,5 +92,12 @@ public class IntTreePMapTest extends TestCase {
   public void testSingleton() {
     UtilityTest.assertEqualsAndHash(
         IntTreePMap.empty().plus(10, "test"), IntTreePMap.singleton(10, "test"));
+  }
+
+  public void testUnmodifiable() {
+    assertMapMutatorsThrow(
+        IntTreePMap.singleton(1, "value1"),
+        2, "value2"
+    );
   }
 }

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -14,6 +14,8 @@ import org.pcollections.OrderedPSet;
 import org.pcollections.POrderedSet;
 import org.pcollections.PSet;
 
+import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
+
 public class OrderedPSetTest extends TestCase {
 
   public void testPlus() {
@@ -66,5 +68,9 @@ public class OrderedPSetTest extends TestCase {
   public void testIterator() {
     UtilityTest.iteratorExceptions(Empty.orderedSet().iterator());
     UtilityTest.iteratorExceptions(OrderedPSet.singleton(10).iterator());
+  }
+
+  public void testUnmodifiable() {
+    assertSetMutatorsThrow(OrderedPSet.singleton("value1"), "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -48,7 +48,7 @@ public class OrderedPSetTest extends TestCase {
     PSet<Integer> s = Empty.set();
     POrderedSet<Integer> os = Empty.orderedSet();
 
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 100000; i++) {
       int v = r.nextInt(1000);
       if (r.nextFloat() < 0.8) {

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -46,7 +46,7 @@ public class TreePMapTest extends TestCase {
    */
   private static final TreePMap<Integer, String> EMPTY = TreePMap.empty();
 
-  private static final Random RANDOM = new Random();
+  private static final Random RANDOM = new Random(123);
 
   private static final Comparator<Object> STRING_ORDER_COMPARATOR = StringOrderComparator.INSTANCE;
 

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -39,6 +39,8 @@ import org.pcollections.TreePSet;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
 import org.pcollections.tests.util.StringOrderComparator;
 
+import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
+
 public class TreePMapTest extends TestCase {
   /**
    * An empty TreePMap&lt;Integer, String&gt; using the natural ordering; useful in cases where type
@@ -1279,5 +1281,12 @@ public class TreePMapTest extends TestCase {
       treeMap = treeMap.plus(key, keyToValue.apply(key));
     }
     return treeMap;
+  }
+
+  public void testUnmodifiable() {
+    assertMapMutatorsThrow(
+        TreePMap.singleton("key1", "value1"),
+        "key2", "value2"
+    );
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -36,7 +36,7 @@ public class TreePSetTest extends TestCase {
    */
   private static final TreePSet<Integer> EMPTY = TreePSet.empty();
 
-  private static final Random RANDOM = new Random();
+  private static final Random RANDOM = new Random(123);
 
   private static final Comparator<Object> STRING_ORDER_COMPARATOR = StringOrderComparator.INSTANCE;
 

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -29,6 +29,8 @@ import org.pcollections.TreePSet;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
 import org.pcollections.tests.util.StringOrderComparator;
 
+import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
+
 public class TreePSetTest extends TestCase {
   /**
    * An empty TreePSet&lt;Integer&gt; using the natural ordering; useful in cases where type
@@ -996,5 +998,9 @@ public class TreePSetTest extends TestCase {
 
   private static TreeSet<Integer> treeSetOf(final Integer... elements) {
     return new TreeSet<>(Arrays.asList(elements));
+  }
+
+  public void testUnmodifiable() {
+    assertSetMutatorsThrow(TreePSet.singleton("value1"), "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePVectorTest.java
+++ b/src/test/java/org/pcollections/tests/TreePVectorTest.java
@@ -19,7 +19,7 @@ public class TreePVectorTest extends TestCase {
   public void testRandomlyAgainstJavaList() {
     PVector<Integer> pvec = TreePVector.empty();
     List<Integer> list = new LinkedList<Integer>();
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 1000; i++) {
       if (pvec.size() == 0 || r.nextBoolean()) { // add
         if (r.nextBoolean()) { // append

--- a/src/test/java/org/pcollections/tests/UtilityTest.java
+++ b/src/test/java/org/pcollections/tests/UtilityTest.java
@@ -111,7 +111,7 @@ public class UtilityTest extends TestCase {
   }
 
   static void sequenceExceptions(PSequence<Integer> pseq) {
-    Random r = new Random();
+    Random r = new Random(123);
     for (int i = 0; i < 100; i++) {
       int j = r.nextInt(100) - 10, size0 = 0;
       boolean inBounds = false;

--- a/src/test/java/org/pcollections/tests/util/UnmodifiableAssertions.java
+++ b/src/test/java/org/pcollections/tests/util/UnmodifiableAssertions.java
@@ -1,0 +1,24 @@
+package org.pcollections.tests.util;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class UnmodifiableAssertions {
+
+	public static <K,V> void assertMapMutatorsThrow(Map<K,V> map, K sampleKey, V sampleValue) {
+		assertThrows(UnsupportedOperationException.class, map::clear);
+		assertThrows(UnsupportedOperationException.class, ()->map.compute(sampleKey, (k,v)->fail()));
+		assertThrows(UnsupportedOperationException.class, ()->map.computeIfAbsent(sampleKey, (k)->fail()));
+		assertThrows(UnsupportedOperationException.class, ()->map.computeIfPresent(sampleKey, (k,v)->fail()));
+		assertThrows(UnsupportedOperationException.class, ()->map.merge(sampleKey, sampleValue, (k,v)->fail()));
+		assertThrows(UnsupportedOperationException.class, ()->map.put(sampleKey, sampleValue));
+		assertThrows(UnsupportedOperationException.class, ()->map.putAll(map));
+		assertThrows(UnsupportedOperationException.class, ()->map.putIfAbsent(sampleKey, sampleValue));
+		assertThrows(UnsupportedOperationException.class, ()->map.remove(sampleKey));
+		assertThrows(UnsupportedOperationException.class, ()->map.replace(sampleKey, sampleValue));
+		assertThrows(UnsupportedOperationException.class, ()->map.replaceAll((k,v)->fail()));
+	}
+
+}

--- a/src/test/java/org/pcollections/tests/util/UnmodifiableAssertions.java
+++ b/src/test/java/org/pcollections/tests/util/UnmodifiableAssertions.java
@@ -1,11 +1,25 @@
 package org.pcollections.tests.util;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class UnmodifiableAssertions {
+
+	public static <V> void assertSetMutatorsThrow(Set<V> set, V sampleValue) {
+		assertThrows(UnsupportedOperationException.class, ()->set.add(sampleValue));
+		assertThrows(UnsupportedOperationException.class, ()->set.addAll(asList(sampleValue, sampleValue)));
+		assertThrows(UnsupportedOperationException.class, set::clear);
+		assertThrows(UnsupportedOperationException.class, ()->set.remove(sampleValue));
+		assertThrows(UnsupportedOperationException.class, ()->set.removeAll(asList(sampleValue, sampleValue)));
+		assertThrows(UnsupportedOperationException.class, ()->set.removeIf(__->true));
+		assertThrows(UnsupportedOperationException.class, ()->set.retainAll(asList(sampleValue, sampleValue)));
+	}
 
 	public static <K,V> void assertMapMutatorsThrow(Map<K,V> map, K sampleKey, V sampleValue) {
 		assertThrows(UnsupportedOperationException.class, map::clear);


### PR DESCRIPTION
Selfishly implement the parts of #93 that affect me personally. Because these structures don't obey the contract of `Map` and `Set`, I can't use them as drop-in replacements without failing my own unit tests.

Three lines of real changes; 90 more lines around unit testing.

(Also adds seeds to the randomized unit tests to make them reproducible.)