### PR TITLE
speed up OrderedPSet.minus()

### DIFF
--- a/src/main/java/org/pcollections/POrderedSet.java
+++ b/src/main/java/org/pcollections/POrderedSet.java
@@ -28,8 +28,4 @@ public interface POrderedSet<E> extends PSet<E> {
   public POrderedSet<E> minus(Object e);
 
   public POrderedSet<E> minusAll(Collection<?> list);
-
-  E get(int index);
-
-  int indexOf(Object o);
 }

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -27,7 +27,6 @@ public class OrderedPSetTest extends TestCase {
 
     Iterator<Integer> it = s.iterator();
     for (int i = 0; i < vals.length; i++) {
-      assertEquals(vals[i], s.get(i).intValue());
       assertEquals(vals[i], it.next().intValue());
     }
   }
@@ -41,7 +40,6 @@ public class OrderedPSetTest extends TestCase {
 
     Iterator<Integer> it = s.iterator();
     for (int i = 0; i < vals.length; i++) {
-      assertEquals(vals[i], s.get(i).intValue());
       assertEquals(vals[i], it.next().intValue());
     }
   }

--- a/src/test/java/org/pcollections/tests/SerializationTest.java
+++ b/src/test/java/org/pcollections/tests/SerializationTest.java
@@ -176,10 +176,6 @@ public class SerializationTest extends TestCase {
     assertNotNull(deserializedOrderedPSet);
     assertEquals(3, deserializedOrderedPSet.size());
     assertNotSame(initialOrderedPSet, deserializedOrderedPSet);
-
-    assertEquals(0, deserializedOrderedPSet.indexOf(ELEMENT1));
-    assertEquals(1, deserializedOrderedPSet.indexOf(ELEMENT2));
-    assertEquals(2, deserializedOrderedPSet.indexOf(ELEMENT3));
   }
 
   public void testSerializationForTreePVector() {


### PR DESCRIPTION
As reported in #95 `OrderedPSet.minus()` was linear, so this makes it logarithmic, by switching from a vector to a map.

Benchmarks shows no performance regression for other methods, while `ordered_pset_plus_minus_reverse` is sped up significantly (and this is just for 1000 elements, for more elements the speedup would be even better):

```
=Old=
contains                                LINEAR     61.398  ops/s
contains                                RANDOM     80.600  ops/s
iterator                                LINEAR  62685.475  ops/s
iterator                                RANDOM  65744.581  ops/s
notContains                             LINEAR     60.679  ops/s
notContains                             RANDOM     59.028  ops/s
ordered_pset_plus                       LINEAR   1498.706  ops/s
ordered_pset_plus                       RANDOM   1537.080  ops/s
ordered_pset_plus_minus                 LINEAR    737.462  ops/s
ordered_pset_plus_minus                 RANDOM    760.693  ops/s
ordered_pset_plus_minus_reverse         LINEAR     72.744  ops/s
ordered_pset_plus_minus_reverse         RANDOM     72.104  ops/s

=New=
contains                                LINEAR     55.332  ops/s
contains                                RANDOM    109.640  ops/s
iterator                                LINEAR  67770.126  ops/s
iterator                                RANDOM  71336.923  ops/s
notContains                             LINEAR     63.026  ops/s
notContains                             RANDOM     63.748  ops/s
ordered_pset_plus                       LINEAR   1702.410  ops/s
ordered_pset_plus                       RANDOM   1804.350  ops/s
ordered_pset_plus_minus                 LINEAR    839.788  ops/s
ordered_pset_plus_minus                 RANDOM    827.643  ops/s
ordered_pset_plus_minus_reverse         LINEAR    898.002  ops/s
ordered_pset_plus_minus_reverse         RANDOM    873.489  ops/s
```

(Note these ops/s are actually thousands of operations per second.)

This change means `get()` and `indexOf()` can't be efficient anymore, but they should probably have never been there in the first place, since the analogous class LinkedHashSet doesn't have them, so this removes them. Thus this is a breaking change, so it can be part of the upcoming major version release.

Closes #95 