### PR TITLE
PSet.intersect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.0"
     testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
     testCompile 'org.assertj:assertj-core:3.23.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ repositories {
 
 dependencies {
     // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testCompile 'org.junit.vintage:junit-vintage-engine:5.1.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
     testCompile 'org.assertj:assertj-core:3.9.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
-    testCompile 'org.assertj:assertj-core:3.9.1'
+    testCompile 'org.assertj:assertj-core:3.23.1'
 }
 
 test {

--- a/src/main/java/org/pcollections/PSet.java
+++ b/src/main/java/org/pcollections/PSet.java
@@ -24,4 +24,8 @@ public interface PSet<E> extends PCollection<E>, Set<E> {
   public PSet<E> minus(Object e);
   // @Override
   public PSet<E> minusAll(Collection<?> list);
+
+  public default PSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
 }

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -6,15 +6,23 @@
 
 package org.pcollections.tests;
 
+import static java.util.stream.Collectors.toList;
+import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 import junit.framework.TestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.pcollections.Empty;
 import org.pcollections.OrderedPSet;
 import org.pcollections.POrderedSet;
 import org.pcollections.PSet;
+import org.pcollections.TreePSet;
 
 public class OrderedPSetTest extends TestCase {
 
@@ -70,5 +78,22 @@ public class OrderedPSetTest extends TestCase {
 
   public void testUnmodifiable() {
     assertSetMutatorsThrow(OrderedPSet.singleton("value1"), "value2");
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void treePSet_hasSetSemantics(List<String> left, List<String> right) {
+    assertSetSemantics(OrderedPSet.from(left), right);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void intersect_correctOrder(List<String> left, List<String> right) {
+    List<String> expected = left.stream()
+        .distinct()
+        .filter(right::contains)
+        .collect(toList());
+    List<String> actual = new ArrayList<>(OrderedPSet.from(left).intersect(right));
+    assertEquals(expected, actual);
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -6,6 +6,8 @@
 
 package org.pcollections.tests;
 
+import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
+import static org.pcollections.tests.util.CollectionHelpers.collectionElementCases;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
 import java.io.ByteArrayInputStream;
@@ -25,9 +27,14 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.pcollections.TreePSet;
+import org.pcollections.tests.util.CollectionHelpers;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
 import org.pcollections.tests.util.StringOrderComparator;
 
@@ -1003,4 +1010,11 @@ public class TreePSetTest extends TestCase {
   public void testUnmodifiable() {
     assertSetMutatorsThrow(TreePSet.singleton("value1"), "value2");
   }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void treePSet_hasSetSemantics(List<String> left, List<String> right) {
+    assertSetSemantics(TreePSet.from(left), right);
+  }
+
 }

--- a/src/test/java/org/pcollections/tests/util/CollectionHelpers.java
+++ b/src/test/java/org/pcollections/tests/util/CollectionHelpers.java
@@ -1,0 +1,63 @@
+package org.pcollections.tests.util;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import junit.framework.TestCase;
+import org.junit.jupiter.params.provider.Arguments;
+import org.pcollections.PSet;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class CollectionHelpers {
+
+  public static Stream<Arguments> collectionElementCases() {
+    return elementLists().map(Arguments::of);
+  }
+
+  private static Stream<List<?>> elementLists() {
+    return Stream.of(
+      emptyList(),
+      singletonList("item"),
+      asList("first", "second", "third"),
+      asList("spam", "spam", "bacon"),
+      asList("spam", "bacon", "spam"),
+      asList("bacon", "spam", "spam"),
+      asList("bacon", "spam", "spam", "eggs")
+    );
+  }
+
+  public static Stream<Arguments> collectionElementPairCases() {
+    return elementLists()
+      .flatMap(left -> elementLists()
+        .map(right -> Arguments.of(left, right)));
+  }
+
+  public static <E> void assertSetSemantics(PSet<E> left, Collection<E> right) {
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.addAll(right);
+      TestCase.assertEquals(
+        String.format("plusAll should match addAll for %s and %s", left, right),
+        expected, left.plusAll(right));
+    }
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.removeAll(right);
+      TestCase.assertEquals(
+        String.format("minusAll should match removeAll for %s and %s", left, right),
+        expected, left.minusAll(right));
+    }
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.retainAll(right);
+      TestCase.assertEquals(
+        String.format("intersect should match retainAll for %s and %s", left, right),
+        expected, left.intersect(right));
+    }
+  }
+}


### PR DESCRIPTION
Fixes #96.

### Unit tests
I've included some JUnit5 `@ParameterizedTest`s. Apologies that the naming scheme for the test methods is so different. The existing JUnit4 scheme won't work because JUnit4 will think they're JUnit4 tests and they won't work. Since JUnit5 needs a different convention anyway, I've used the one I'm accustomed to, which takes the form `conditions_expectedResult`.