### PR TITLE
Add unit tests for nulls, plus some null checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.0"
     testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
     testCompile 'org.assertj:assertj-core:3.23.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ repositories {
 
 dependencies {
     // Use JUnit 5: JUnit Jupiter + JUnit Vintage [for running JUnit 3/4 tests as well]
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testCompile 'org.junit.vintage:junit-vintage-engine:5.1.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
     testCompile 'org.assertj:assertj-core:3.9.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testCompile 'org.junit.vintage:junit-vintage-engine:5.9.0'
-    testCompile 'org.assertj:assertj-core:3.9.1'
+    testCompile 'org.assertj:assertj-core:3.23.1'
 }
 
 test {

--- a/src/main/java/org/pcollections/ConsPStack.java
+++ b/src/main/java/org/pcollections/ConsPStack.java
@@ -12,6 +12,8 @@ import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A simple persistent stack of non-null values.
  *
@@ -80,8 +82,8 @@ public final class ConsPStack<E> extends AbstractUnmodifiableSequentialList<E>
   }
 
   private ConsPStack(final E first, final ConsPStack<E> rest) {
-    this.first = first;
-    this.rest = rest;
+    this.first = requireNonNull(first, "first is null");
+    this.rest = requireNonNull(rest, "rest is null");
 
     size = 1 + rest.size;
   }

--- a/src/main/java/org/pcollections/IntTreePMap.java
+++ b/src/main/java/org/pcollections/IntTreePMap.java
@@ -13,6 +13,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * An efficient persistent map from integer keys to non-null values.
  *
@@ -162,7 +164,7 @@ public final class IntTreePMap<V> extends AbstractUnmodifiableMap<Integer, V>
   }
 
   public IntTreePMap<V> minus(final Object key) {
-    if (!(key instanceof Integer)) return this;
+    if (!(requireNonNull(key, "key is null") instanceof Integer)) return this;
     return withRoot(root.minus((Integer) key));
   }
 
@@ -175,7 +177,11 @@ public final class IntTreePMap<V> extends AbstractUnmodifiableMap<Integer, V>
 
   public IntTreePMap<V> minusAll(final Collection<?> keys) {
     IntTree<V> root = this.root;
-    for (Object key : keys) if (key instanceof Integer) root = root.minus((Integer) key);
+    for (Object key : keys) {
+      if (requireNonNull(key, "key is null") instanceof Integer) {
+        root = root.minus((Integer) key);
+      }
+    }
     return withRoot(root);
   }
 }

--- a/src/main/java/org/pcollections/IntTreePMap.java
+++ b/src/main/java/org/pcollections/IntTreePMap.java
@@ -80,7 +80,7 @@ public final class IntTreePMap<V> extends AbstractUnmodifiableMap<Integer, V>
   private final IntTree<V> root;
   // not externally instantiable (or subclassable):
   private IntTreePMap(final IntTree<V> root) {
-    this.root = root;
+    this.root = requireNonNull(root, "root is null");
   }
 
   private IntTreePMap<V> withRoot(final IntTree<V> root) {

--- a/src/main/java/org/pcollections/MapPBag.java
+++ b/src/main/java/org/pcollections/MapPBag.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A map-backed persistent bag.
  *
@@ -40,7 +42,7 @@ public final class MapPBag<E> extends AbstractUnmodifiableCollection<E>
   private final int size;
   // not instantiable (or subclassable):
   private MapPBag(final PMap<E, Integer> map, final int size) {
-    this.map = map;
+    this.map = requireNonNull(map, "map is null");
     this.size = size;
   }
 

--- a/src/main/java/org/pcollections/MapPSet.java
+++ b/src/main/java/org/pcollections/MapPSet.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A map-backed persistent set.
  *
@@ -58,7 +60,7 @@ public final class MapPSet<E> extends AbstractUnmodifiableSet<E> implements PSet
   private final PMap<E, Object> map;
   // not instantiable (or subclassable):
   private MapPSet(final PMap<E, Object> map) {
-    this.map = map;
+    this.map = requireNonNull(map, "map is null");
   }
 
   //// REQUIRED METHODS FROM AbstractSet ////

--- a/src/main/java/org/pcollections/OrderedPSet.java
+++ b/src/main/java/org/pcollections/OrderedPSet.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static java.util.Objects.requireNonNull;
+
 public class OrderedPSet<E> extends AbstractUnmodifiableSet<E>
     implements POrderedSet<E>, Serializable {
 
@@ -37,8 +39,8 @@ public class OrderedPSet<E> extends AbstractUnmodifiableSet<E>
   private final PSortedMap<Long, E> elements;
 
   private OrderedPSet(final PMap<E, Long> ids, final PSortedMap<Long, E> elements) {
-    this.ids = ids;
-    this.elements = elements;
+    this.ids = requireNonNull(ids, "ids is null");
+    this.elements = requireNonNull(elements, "elements is null");
   }
 
   @Override

--- a/src/main/java/org/pcollections/PSet.java
+++ b/src/main/java/org/pcollections/PSet.java
@@ -24,4 +24,8 @@ public interface PSet<E> extends PCollection<E>, Set<E> {
   public PSet<E> minus(Object e);
   // @Override
   public PSet<E> minusAll(Collection<?> list);
+
+  public default PSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
 }

--- a/src/main/java/org/pcollections/TreePSet.java
+++ b/src/main/java/org/pcollections/TreePSet.java
@@ -17,6 +17,8 @@ import java.util.TreeSet;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * An implementation of {@link PSortedSet} based on a self-balancing binary search tree.
  *
@@ -49,11 +51,9 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
       final KVTree<E, ?> tree,
       final Comparator<? super E> ltrComparator,
       final boolean isLeftToRight) {
-    complainIfNull(tree, "tree is null");
-    complainIfNull(ltrComparator, "comparator is null");
 
-    this.tree = tree;
-    this.ltrComparator = ltrComparator;
+    this.tree = requireNonNull(tree, "tree is null");
+    this.ltrComparator = requireNonNull(ltrComparator, "comparator is null");
     this.isLeftToRight = isLeftToRight;
   }
 
@@ -118,9 +118,7 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
    * @throws NullPointerException if the specified set is or contains null
    */
   public static <E> TreePSet<E> fromSortedSet(final SortedSet<E> set) {
-    complainIfNull(set, "set is null");
-
-    if (set instanceof TreePSet<?>) {
+    if (requireNonNull(set, "set is null") instanceof TreePSet<?>) {
       return (TreePSet<E>) set;
     }
 
@@ -130,7 +128,7 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
     {
       final Iterator<? extends Map.Entry<E, ?>> treeIterator = tree.entryIterator(true);
       while (treeIterator.hasNext()) {
-        complainIfNull(treeIterator.next().getKey(), "set contains null element");
+        requireNonNull(treeIterator.next().getKey(), "set contains null element");
       }
     }
 
@@ -221,7 +219,7 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
    */
   public static <E> Collector<E, ?, TreePSet<E>> toTreePSet(
       final Comparator<? super E> comparator) {
-    complainIfNull(comparator, "comparator is null");
+    requireNonNull(comparator, "comparator is null");
 
     return Collectors.collectingAndThen(
         Collectors.toCollection(() -> new TreeSet<E>(comparator)),
@@ -270,7 +268,7 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
 
   @Override
   public TreePSet<E> headSet(final E toElement, final boolean inclusive) {
-    complainIfNull(toElement, "toElement is null");
+    requireNonNull(toElement, "toElement is null");
 
     return this.withTree(
         this.isLeftToRight
@@ -312,19 +310,18 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
 
   @Override
   public TreePSet<E> minus(final Object e) {
-    complainIfNull(e, "element is null");
-
-    return this.withTree(this.tree.minus(sneakilyDowncast(e), this.ltrComparator));
+    return this.withTree(this.tree.minus(
+        sneakilyDowncast(requireNonNull(e, "element is null")),
+        this.ltrComparator));
   }
 
   @Override
   public TreePSet<E> minusAll(final Collection<?> list) {
-    complainIfNull(list, "list is null");
 
     KVTree<E, ?> tree = this.tree;
 
-    for (final Object e : list) {
-      complainIfNull(e, "list contains null element");
+    for (final Object e : requireNonNull(list, "list is null")) {
+      requireNonNull(e, "list contains null element");
 
       tree = tree.minus(sneakilyDowncast(e), this.ltrComparator);
     }
@@ -346,21 +343,21 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
 
   @Override
   public TreePSet<E> plus(final E e) {
-    complainIfNull(e, "element is null");
-
-    return this.withTree(this.tree.plus(e, null, this.ltrComparator));
+    return this.withTree(this.tree.plus(
+        requireNonNull(e, "element is null"),
+      null,
+      this.ltrComparator));
   }
 
   @Override
   public TreePSet<E> plusAll(final Collection<? extends E> list) {
-    complainIfNull(list, "list is null");
-
     KVTree<E, ?> tree = this.tree;
 
-    for (final E e : list) {
-      complainIfNull(e, "list contains null element");
-
-      tree = tree.plus(e, null, this.ltrComparator);
+    for (final E e : requireNonNull(list, "list is null")) {
+      tree = tree.plus(
+          requireNonNull(e, "list contains null element"),
+        null,
+        this.ltrComparator);
     }
 
     return this.withTree(tree);
@@ -382,8 +379,8 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
       final boolean fromInclusive,
       final E toElement,
       final boolean toInclusive) {
-    complainIfNull(fromElement, "fromElement is null");
-    complainIfNull(fromElement, "toElement is null");
+    requireNonNull(fromElement, "fromElement is null");
+    requireNonNull(fromElement, "toElement is null");
 
     if (this.comparator().compare(fromElement, toElement) > 0) {
       throw new IllegalArgumentException("fromElement > toElement");
@@ -406,11 +403,9 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
       final E e,
       final KVTree.SearchType searchTypeIfLeftToRight,
       final KVTree.SearchType searchTypeIfRightToLeft) {
-    complainIfNull(e, "e is null");
-
     return this.tree
         .search(
-            e,
+            requireNonNull(e, "e is null"),
             this.ltrComparator,
             this.isLeftToRight ? searchTypeIfLeftToRight : searchTypeIfRightToLeft)
         .getKey();
@@ -418,7 +413,7 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
 
   @Override
   public TreePSet<E> tailSet(final E fromElement, final boolean inclusive) {
-    complainIfNull(fromElement, "fromElement is null");
+    requireNonNull(fromElement, "fromElement is null");
 
     return this.withTree(
         this.isLeftToRight
@@ -428,12 +423,6 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
 
   private TreePSet<E> withTree(final KVTree<E, ?> tree) {
     return tree == this.tree ? this : new TreePSet<E>(tree, this.ltrComparator, this.isLeftToRight);
-  }
-
-  private static void complainIfNull(final Object o, final String msg) {
-    if (o == null) {
-      throw new NullPointerException(msg);
-    }
   }
 
   // we put this in its own method, to limit the scope of the @SuppressWarnings:

--- a/src/main/java/org/pcollections/TreePVector.java
+++ b/src/main/java/org/pcollections/TreePVector.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A persistent vector of non-null elements.
  *
@@ -67,7 +69,7 @@ public class TreePVector<E> extends AbstractUnmodifiableList<E>
   private final IntTreePMap<E> map;
 
   private TreePVector(final IntTreePMap<E> map) {
-    this.map = map;
+    this.map = requireNonNull(map, "map is null");
   }
 
   //// REQUIRED METHODS FROM AbstractList ////

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -6,6 +6,7 @@
 
 package org.pcollections.tests;
 
+import static org.pcollections.tests.util.NullCheckAssertions.assertMapChecksForNull;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
 
 import java.util.HashMap;
@@ -97,6 +98,11 @@ public class HashPMapTest extends TestCase {
   public void testUnmodifiable() {
     assertMapMutatorsThrow(HashTreePMap.empty(), "key1", "value1");
     assertMapMutatorsThrow(HashTreePMap.singleton("key1", "value1"), "key2", "value2");
+  }
+
+  public void testChecksForNull() {
+    assertMapChecksForNull(HashTreePMap.empty(), "key1", "value1");
+    assertMapChecksForNull(HashTreePMap.singleton("key1", "value1"), "key2", "value2");
   }
 
 }

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -98,4 +98,5 @@ public class HashPMapTest extends TestCase {
     assertMapMutatorsThrow(HashTreePMap.empty(), "key1", "value1");
     assertMapMutatorsThrow(HashTreePMap.singleton("key1", "value1"), "key2", "value2");
   }
+
 }

--- a/src/test/java/org/pcollections/tests/HashPMapTest.java
+++ b/src/test/java/org/pcollections/tests/HashPMapTest.java
@@ -95,6 +95,7 @@ public class HashPMapTest extends TestCase {
   }
 
   public void testUnmodifiable() {
+    assertMapMutatorsThrow(HashTreePMap.empty(), "key1", "value1");
     assertMapMutatorsThrow(HashTreePMap.singleton("key1", "value1"), "key2", "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/IntTreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/IntTreePMapTest.java
@@ -95,6 +95,7 @@ public class IntTreePMapTest extends TestCase {
   }
 
   public void testUnmodifiable() {
+    assertMapMutatorsThrow(IntTreePMap.empty(), 1, "value1");
     assertMapMutatorsThrow(IntTreePMap.singleton(1, "value1"), 2, "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/IntTreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/IntTreePMapTest.java
@@ -6,6 +6,7 @@
 
 package org.pcollections.tests;
 
+import static org.pcollections.tests.util.NullCheckAssertions.assertMapChecksForNull;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
 
 import java.util.HashMap;
@@ -97,5 +98,10 @@ public class IntTreePMapTest extends TestCase {
   public void testUnmodifiable() {
     assertMapMutatorsThrow(IntTreePMap.empty(), 1, "value1");
     assertMapMutatorsThrow(IntTreePMap.singleton(1, "value1"), 2, "value2");
+  }
+
+  public void testChecksForNull() {
+    assertMapChecksForNull(IntTreePMap.empty(), 1, "value1");
+    assertMapChecksForNull(IntTreePMap.singleton(1, "value1"), 2, "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -8,6 +8,7 @@ package org.pcollections.tests;
 
 import static java.util.stream.Collectors.toList;
 import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
+import static org.pcollections.tests.util.NullCheckAssertions.assertSetChecksForNull;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
 import java.util.ArrayList;
@@ -78,6 +79,10 @@ public class OrderedPSetTest extends TestCase {
 
   public void testUnmodifiable() {
     assertSetMutatorsThrow(OrderedPSet.singleton("value1"), "value2");
+  }
+
+  public void testChecksForNull() {
+    assertSetChecksForNull(OrderedPSet.singleton("value1"), "value2");
   }
 
   @ParameterizedTest

--- a/src/test/java/org/pcollections/tests/OrderedPSetTest.java
+++ b/src/test/java/org/pcollections/tests/OrderedPSetTest.java
@@ -6,15 +6,23 @@
 
 package org.pcollections.tests;
 
+import static java.util.stream.Collectors.toList;
+import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 import junit.framework.TestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.pcollections.Empty;
 import org.pcollections.OrderedPSet;
 import org.pcollections.POrderedSet;
 import org.pcollections.PSet;
+import org.pcollections.TreePSet;
 
 public class OrderedPSetTest extends TestCase {
 
@@ -70,5 +78,22 @@ public class OrderedPSetTest extends TestCase {
 
   public void testUnmodifiable() {
     assertSetMutatorsThrow(OrderedPSet.singleton("value1"), "value2");
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void treePSet_hasSetSemantics(List<String> left, List<String> right) {
+    assertSetSemantics(OrderedPSet.from(left), right);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void intersect_correctOrder(List<String> left, List<String> right) {
+    List<String> expected = left.stream()
+        .distinct()
+        .filter(right::contains)
+        .collect(toList());
+    List<String> actual = new ArrayList<>(OrderedPSet.from(left).intersect(right));
+    assertEquals(expected, actual);
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -1284,6 +1284,7 @@ public class TreePMapTest extends TestCase {
   }
 
   public void testUnmodifiable() {
+    assertMapMutatorsThrow(TreePMap.empty(), "key", "value");
     assertMapMutatorsThrow(TreePMap.singleton("key1", "value1"), "key2", "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -6,6 +6,7 @@
 
 package org.pcollections.tests;
 
+import static org.pcollections.tests.util.NullCheckAssertions.assertMapChecksForNull;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertMapMutatorsThrow;
 
 import java.io.ByteArrayInputStream;
@@ -1286,5 +1287,10 @@ public class TreePMapTest extends TestCase {
   public void testUnmodifiable() {
     assertMapMutatorsThrow(TreePMap.empty(), "key", "value");
     assertMapMutatorsThrow(TreePMap.singleton("key1", "value1"), "key2", "value2");
+  }
+
+  public void testChecksForNull() {
+    assertMapChecksForNull(TreePMap.empty(), "key", "value");
+    assertMapChecksForNull(TreePMap.singleton("key1", "value1"), "key2", "value2");
   }
 }

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -33,6 +33,7 @@ import junit.framework.TestCase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.pcollections.HashTreePSet;
 import org.pcollections.TreePSet;
 import org.pcollections.tests.util.CollectionHelpers;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
@@ -1008,7 +1009,10 @@ public class TreePSetTest extends TestCase {
   }
 
   public void testUnmodifiable() {
+    assertSetMutatorsThrow(TreePSet.empty(), "value");
     assertSetMutatorsThrow(TreePSet.singleton("value1"), "value2");
+    assertSetMutatorsThrow(HashTreePSet.empty(), "value");
+    assertSetMutatorsThrow(HashTreePSet.singleton("value1"), "value2");
   }
 
   @ParameterizedTest

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -8,6 +8,7 @@ package org.pcollections.tests;
 
 import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
 import static org.pcollections.tests.util.CollectionHelpers.collectionElementCases;
+import static org.pcollections.tests.util.NullCheckAssertions.assertSetChecksForNull;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
 import java.io.ByteArrayInputStream;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcollections.HashTreePSet;
+import org.pcollections.OrderedPSet;
 import org.pcollections.TreePSet;
 import org.pcollections.tests.util.CollectionHelpers;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
@@ -1013,6 +1015,13 @@ public class TreePSetTest extends TestCase {
     assertSetMutatorsThrow(TreePSet.singleton("value1"), "value2");
     assertSetMutatorsThrow(HashTreePSet.empty(), "value");
     assertSetMutatorsThrow(HashTreePSet.singleton("value1"), "value2");
+  }
+
+  public void testChecksForNull() {
+    assertSetChecksForNull(TreePSet.empty(), "value");
+    assertSetChecksForNull(TreePSet.singleton("value1"), "value2");
+    assertSetChecksForNull(HashTreePSet.empty(), "value");
+    assertSetChecksForNull(HashTreePSet.singleton("value1"), "value2");
   }
 
   @ParameterizedTest

--- a/src/test/java/org/pcollections/tests/TreePSetTest.java
+++ b/src/test/java/org/pcollections/tests/TreePSetTest.java
@@ -6,6 +6,8 @@
 
 package org.pcollections.tests;
 
+import static org.pcollections.tests.util.CollectionHelpers.assertSetSemantics;
+import static org.pcollections.tests.util.CollectionHelpers.collectionElementCases;
 import static org.pcollections.tests.util.UnmodifiableAssertions.assertSetMutatorsThrow;
 
 import java.io.ByteArrayInputStream;
@@ -25,9 +27,14 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.pcollections.TreePSet;
+import org.pcollections.tests.util.CollectionHelpers;
 import org.pcollections.tests.util.CompareInconsistentWithEquals;
 import org.pcollections.tests.util.StringOrderComparator;
 
@@ -1003,4 +1010,11 @@ public class TreePSetTest extends TestCase {
   public void testUnmodifiable() {
     assertSetMutatorsThrow(TreePSet.singleton("value1"), "value2");
   }
+
+  @ParameterizedTest
+  @MethodSource("org.pcollections.tests.util.CollectionHelpers#collectionElementPairCases")
+  public void treePSet_hasSetSemantics(List<String> left, List<String> right) {
+    assertSetSemantics(TreePSet.from(left), right);
+  }
+
 }

--- a/src/test/java/org/pcollections/tests/util/CollectionHelpers.java
+++ b/src/test/java/org/pcollections/tests/util/CollectionHelpers.java
@@ -1,0 +1,63 @@
+package org.pcollections.tests.util;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import junit.framework.TestCase;
+import org.junit.jupiter.params.provider.Arguments;
+import org.pcollections.PSet;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class CollectionHelpers {
+
+  public static Stream<Arguments> collectionElementCases() {
+    return elementLists().map(Arguments::of);
+  }
+
+  private static Stream<List<?>> elementLists() {
+    return Stream.of(
+      emptyList(),
+      singletonList("item"),
+      asList("first", "second", "third"),
+      asList("spam", "spam", "bacon"),
+      asList("spam", "bacon", "spam"),
+      asList("bacon", "spam", "spam"),
+      asList("bacon", "spam", "spam", "eggs")
+    );
+  }
+
+  public static Stream<Arguments> collectionElementPairCases() {
+    return elementLists()
+      .flatMap(left -> elementLists()
+        .map(right -> Arguments.of(left, right)));
+  }
+
+  public static <E> void assertSetSemantics(PSet<E> left, Collection<E> right) {
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.addAll(right);
+      TestCase.assertEquals(
+        String.format("plusAll should match addAll for %s and %s", left, right),
+        expected, left.plusAll(right));
+    }
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.removeAll(right);
+      TestCase.assertEquals(
+        String.format("minusAll should match removeAll for %s and %s", left, right),
+        expected, left.minusAll(right));
+    }
+    {
+      Set<E> expected = new HashSet<>(left);
+      expected.retainAll(right);
+      TestCase.assertEquals(
+        String.format("intersect should match retainAll for %s and %s", left, right),
+        expected, left.intersect(right));
+    }
+  }
+}

--- a/src/test/java/org/pcollections/tests/util/NullCheckAssertions.java
+++ b/src/test/java/org/pcollections/tests/util/NullCheckAssertions.java
@@ -1,9 +1,12 @@
 package org.pcollections.tests.util;
 
+import java.util.Collections;
 import org.junit.jupiter.api.function.Executable;
+import org.pcollections.PMap;
 import org.pcollections.PSet;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NullCheckAssertions {
@@ -15,6 +18,15 @@ public class NullCheckAssertions {
 		assertNPE(() -> set.minusAll(asList(sampleValue, null)));
 		assertNPE(() -> set.intersect(asList(sampleValue, null)));
 		// Could also check for contains and containsAll; is that overly strict?
+	}
+
+	public static <K,V> void assertMapChecksForNull(PMap<K,V> map, K sampleKey, V sampleValue) {
+//		assertNPE(() -> map.plus(sampleKey, null));
+		assertNPE(() -> map.plus(null, sampleValue));
+//		assertNPE(() -> map.plusAll(singletonMap(sampleKey, null)));
+		assertNPE(() -> map.plusAll(singletonMap(null, sampleValue)));
+		assertNPE(() -> map.minus(null));
+		assertNPE(() -> map.minusAll(asList(sampleKey, null)));
 	}
 
 	static void assertNPE(Executable executable) {

--- a/src/test/java/org/pcollections/tests/util/NullCheckAssertions.java
+++ b/src/test/java/org/pcollections/tests/util/NullCheckAssertions.java
@@ -1,0 +1,23 @@
+package org.pcollections.tests.util;
+
+import org.junit.jupiter.api.function.Executable;
+import org.pcollections.PSet;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NullCheckAssertions {
+
+	public static <V> void assertSetChecksForNull(PSet<V> set, V sampleValue) {
+		assertNPE(() -> set.plus(null));
+		assertNPE(() -> set.plusAll(asList(sampleValue, null)));
+		assertNPE(() -> set.minus(null));
+		assertNPE(() -> set.minusAll(asList(sampleValue, null)));
+		assertNPE(() -> set.intersect(asList(sampleValue, null)));
+		// Could also check for contains and containsAll; is that overly strict?
+	}
+
+	static void assertNPE(Executable executable) {
+		assertThrows(NullPointerException.class, executable);
+	}
+}


### PR DESCRIPTION
_Mostly_ fixes #54.  I did not add checks for null values in maps. It's not clear to me that we should forbid this anyway.

Besides that, it turns out we were mostly already throwing NPE for nulls. The only missing ones were the `IntTreePMap` `minus` methods.

I also switched to using the built-in `requireNonNull` method instead of our own bespoke one, and added some additional null checks in all the constructors for good measure.

### Dependency note

This PR is built on top of #99, because I wanted to test that `PSet.intersect` correctly detected nulls. I can rebase this one once that one is merged, if you want.