### PR TITLE
Covariant return types for intersect methods

### DIFF
--- a/src/main/java/org/pcollections/MapPSet.java
+++ b/src/main/java/org/pcollections/MapPSet.java
@@ -103,4 +103,9 @@ public final class MapPSet<E> extends AbstractUnmodifiableSet<E> implements PSet
     PMap<E, Object> map = this.map.minusAll(list);
     return from(map);
   }
+
+  @Override
+  public MapPSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
 }

--- a/src/main/java/org/pcollections/OrderedPSet.java
+++ b/src/main/java/org/pcollections/OrderedPSet.java
@@ -85,6 +85,11 @@ public class OrderedPSet<E> extends AbstractUnmodifiableSet<E> implements PSet<E
   }
 
   @Override
+  public OrderedPSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
+
+  @Override
   public Iterator<E> iterator() {
     return elements.values().iterator();
   }

--- a/src/main/java/org/pcollections/PSet.java
+++ b/src/main/java/org/pcollections/PSet.java
@@ -25,6 +25,9 @@ public interface PSet<E> extends PCollection<E>, Set<E> {
   // @Override
   public PSet<E> minusAll(Collection<?> list);
 
+  /**
+   * @return the equivalent of <code>this.minusAll(this.minusAll(list))</code>.
+   */
   public default PSet<E> intersect(Collection<? extends E> list) {
     return this.minusAll(this.minusAll(list));
   }

--- a/src/main/java/org/pcollections/PSortedSet.java
+++ b/src/main/java/org/pcollections/PSortedSet.java
@@ -112,6 +112,11 @@ public interface PSortedSet<E> extends PSet<E>, NavigableSet<E> {
   @Override
   public PSortedSet<E> minusAll(Collection<?> list);
 
+  @Override
+  default PSortedSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
+
   /**
    * @return This set, except with its first (least) element removed.
    * @throws NoSuchElementException if this set is empty

--- a/src/main/java/org/pcollections/TreePSet.java
+++ b/src/main/java/org/pcollections/TreePSet.java
@@ -332,6 +332,11 @@ public final class TreePSet<E> extends AbstractUnmodifiableSet<E>
   }
 
   @Override
+  public TreePSet<E> intersect(Collection<? extends E> list) {
+    return this.minusAll(this.minusAll(list));
+  }
+
+  @Override
   public TreePSet<E> minusFirst() {
     return this.withTree(
         this.isLeftToRight ? this.tree.minusLeftmost() : this.tree.minusRightmost());


### PR DESCRIPTION
The `minusAll` method is overridden in subtypes of `PSet` so that it returns those particular subtypes.

This PR does the same for `intersect`.

### Implementation notes

The DRY principle would suggest that the subtypes should call the `super` version of the method. However, this would require a downcast. I opted instead to just duplicate the one-liner method implementation, but perhaps the downcast would be cleaner?