### PR TITLE
Supply dummy ossrh credentials when none available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,8 @@ publishing {
       url version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
       credentials {
-        username ossrhUsername
-        password ossrhPassword
+        username providers.gradleProperty('ossrhUsername').getOrElse('dummy')
+        password providers.gradleProperty('ossrhPassword').getOrElse('dummy')
       }
     }
   }


### PR DESCRIPTION
This enables commands like `./gradlew build` to work without supplying credentials in a gradle.properties file.

Now with no `gradle.properties` file in the project dir or your `~/.gradle` dir you can run commands like `./gradlew build` and `./gradlew test`

```shell
[roby@roby pcollections]$ ./gradlew clean test

> Configure project :
Project : => 'org.pcollections' Java module

> Task :compileTestJava
warning: [options] module name in --add-exports option not found: org.junit.jupiter.engine
1 warning

BUILD SUCCESSFUL in 5s
```

And to check it's picking up the property from the required locations:

1. no gradle.properties file

```shell
./gradlew publish -xsignMavenJavaPublication --debug | grep dummy
2023-11-08T12:00:44.248+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: dummy] and NTLM Credentials [user: dummy, domain: , workstation: ROBY] for authenticating against 'oss.sonatype.org:-1' using NTLM
2023-11-08T12:00:44.248+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: dummy] for authenticating against 'oss.sonatype.org:-1' using null
```

2. with gradle.properties containing name/pass == "real" in the project dir
```shell
./gradlew publish -xsignMavenJavaPublication --debug | grep real
2023-11-08T12:01:28.727+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: real] and NTLM Credentials [user: real, domain: , workstation: ROBY] for authenticating against 'oss.sonatype.org:-1' using NTLM
2023-11-08T12:01:28.727+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: real] for authenticating against 'oss.sonatype.org:-1' using null
```

3. with gradle.properties containing name/pass == "real" in `~/.gradle`
```shell
./gradlew publish -xsignMavenJavaPublication --debug | grep real
2023-11-08T12:02:12.949+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: real] and NTLM Credentials [user: real, domain: , workstation: ROBY] for authenticating against 'oss.sonatype.org:-1' using NTLM
2023-11-08T12:02:12.949+1300 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: real] for authenticating against 'oss.sonatype.org:-1' using null
```

Why:
The context is we are rebuilding from source and publishing to a custom maven repository and currently have to inject a gradle.properties file to make the gradle build run.

Closes #112 