### PR TITLE
Fix Javadoc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ which still leaves `y` untouched but generally requires little or no copying, us
 
 ### Usage
 
-PCollections are created using producers and static factory methods. Some example static factory methods are [`HashTreePSet.empty()`](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html#empty()) which returns an empty [PSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSet.html), while `HashTreePSet.singleton(e)` returns a PSet containing just the element `e`, and `HashTreePSet.from(collection)` returns a PSet containing the same elements as `collection`. See [Example Code](#example-code) below for an example of using producers.
+PCollections are created using producers and static factory methods. Some example static factory methods are [`HashTreePSet.empty()`](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html#empty()) which returns an empty [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSet.html), while `HashTreePSet.singleton(e)` returns a PSet containing just the element `e`, and `HashTreePSet.from(collection)` returns a PSet containing the same elements as `collection`. See [Example Code](#example-code) below for an example of using producers.
 
 The same `empty()`, `singleton()`, and `from()` factory methods are found in each of the PCollections implementations, which currently include one concrete implementation for each abstract type:
-* [HashTreePMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePMap.html) provides a [PMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PMap.html) implementation, analogous to Java's HashMap.
-* [TreePMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePMap.html) provides a
-[PSortedMap](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSortedMap.html) implementation,
+* [HashTreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePMap.html) provides a [PMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PMap.html) implementation, analogous to Java's HashMap.
+* [TreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePMap.html) provides a
+[PSortedMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSortedMap.html) implementation,
 analogous to Java's TreeMap.
-* [ConsPStack](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/ConsPStack.html) provides a [PStack](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PStack.html) implementation, analogous to Java's LinkedList.
-* [TreePVector](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePVector.html) provides a [PVector](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PVector.html) implementation, analogous to Java's ArrayList.
-* [HashTreePSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html) provides a [PSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSet.html) implementation, analogous to Java's HashSet.
-* [TreePSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/TreePSet.html) provides a
-[PSortedSet](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PSortedSet.html) implementation,
+* [ConsPStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/ConsPStack.html) provides a [PStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PStack.html) implementation, analogous to Java's LinkedList.
+* [TreePVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePVector.html) provides a [PVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PVector.html) implementation, analogous to Java's ArrayList.
+* [HashTreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html) provides a [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSet.html) implementation, analogous to Java's HashSet.
+* [TreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePSet.html) provides a
+[PSortedSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSortedSet.html) implementation,
 analogous to Java's TreeSet.
-* [HashTreePBag](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/HashTreePBag.html) provides a [PBag](https://javadoc.io/page/org.pcollections/pcollections/latest/org/pcollections/PBag.html) implementation, which is unordered like a set but can contain duplicate elements.
+* [HashTreePBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePBag.html) provides a [PBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PBag.html) implementation, which is unordered like a set but can contain duplicate elements.
 
 PCollections are highly interoperable with Java Collections:
 

--- a/README.md
+++ b/README.md
@@ -31,20 +31,20 @@ which still leaves `y` untouched but generally requires little or no copying, us
 
 ### Usage
 
-PCollections are created using producers and static factory methods. Some example static factory methods are [`HashTreePSet.empty()`](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html#empty()) which returns an empty [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSet.html), while `HashTreePSet.singleton(e)` returns a PSet containing just the element `e`, and `HashTreePSet.from(collection)` returns a PSet containing the same elements as `collection`. See [Example Code](#example-code) below for an example of using producers.
+PCollections are created using producers and static factory methods. Some example static factory methods are [`HashTreePSet.empty()`](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/HashTreePSet.html#empty()) which returns an empty [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PSet.html), while `HashTreePSet.singleton(e)` returns a PSet containing just the element `e`, and `HashTreePSet.from(collection)` returns a PSet containing the same elements as `collection`. See [Example Code](#example-code) below for an example of using producers.
 
 The same `empty()`, `singleton()`, and `from()` factory methods are found in each of the PCollections implementations, which currently include one concrete implementation for each abstract type:
-* [HashTreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePMap.html) provides a [PMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PMap.html) implementation, analogous to Java's HashMap.
-* [TreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePMap.html) provides a
-[PSortedMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSortedMap.html) implementation,
+* [HashTreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/HashTreePMap.html) provides a [PMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PMap.html) implementation, analogous to Java's HashMap.
+* [TreePMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/TreePMap.html) provides a
+[PSortedMap](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PSortedMap.html) implementation,
 analogous to Java's TreeMap.
-* [ConsPStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/ConsPStack.html) provides a [PStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PStack.html) implementation, analogous to Java's LinkedList.
-* [TreePVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePVector.html) provides a [PVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PVector.html) implementation, analogous to Java's ArrayList.
-* [HashTreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePSet.html) provides a [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSet.html) implementation, analogous to Java's HashSet.
-* [TreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/TreePSet.html) provides a
-[PSortedSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PSortedSet.html) implementation,
+* [ConsPStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/ConsPStack.html) provides a [PStack](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PStack.html) implementation, analogous to Java's LinkedList.
+* [TreePVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/TreePVector.html) provides a [PVector](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PVector.html) implementation, analogous to Java's ArrayList.
+* [HashTreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/HashTreePSet.html) provides a [PSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PSet.html) implementation, analogous to Java's HashSet.
+* [TreePSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/TreePSet.html) provides a
+[PSortedSet](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PSortedSet.html) implementation,
 analogous to Java's TreeSet.
-* [HashTreePBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/HashTreePBag.html) provides a [PBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org/pcollections/PBag.html) implementation, which is unordered like a set but can contain duplicate elements.
+* [HashTreePBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/HashTreePBag.html) provides a [PBag](https://javadoc.io/doc/org.pcollections/pcollections/latest/org.pcollections/org/pcollections/PBag.html) implementation, which is unordered like a set but can contain duplicate elements.
 
 PCollections are highly interoperable with Java Collections:
 


### PR DESCRIPTION
Possibly the URL scheme changed on javadoc.io.