### PR TITLE
fixes serialization issue in TreePMap

### DIFF
--- a/src/main/java/org/pcollections/KVTree.java
+++ b/src/main/java/org/pcollections/KVTree.java
@@ -543,6 +543,13 @@ final class KVTree<K, V> implements Map.Entry<K, V>, Serializable {
     return this.key + "=" + this.value;
   }
 
+  private Object readResolve() {
+    if (size == 0) {
+      return EMPTY;
+    }
+    return this;
+  }
+
   private void checkNotEmpty() {
     if (this.isEmpty()) {
       throw new NoSuchElementException();

--- a/src/test/java/org/pcollections/tests/TreePMapTest.java
+++ b/src/test/java/org/pcollections/tests/TreePMapTest.java
@@ -839,6 +839,10 @@ public class TreePMapTest extends TestCase {
             treePMapOf(STRING_ORDER_COMPARATOR, STRINGIFY, 1, 2, 3, 4).descendingMap()));
   }
 
+  public void testSerializationAndDeserializationOfEmpty() throws Exception {
+    assertTrue(serializeAndDeserialize(TreePMap.empty()).isEmpty());
+  }
+
   public void testSingleton() {
     // the overload that doesn't take an explicit comparator (uses natural ordering):
 


### PR DESCRIPTION
Hi, I found an issue in TreePMap when a empty map is serialized and deserialized.

```java
  public void testSerializationAndDeserializationOfEmpty() throws Exception {
    assertTrue(serializeAndDeserialize(TreePMap.empty()).isEmpty());
  }
```

After the object is deserialized when you call `isEmpty` method returns `false`, but `size()` method returns `0`.

To fix the issue to preserve the EMPTY object of KVTree as a singleton, I implemented the method readResolve to return the EMPTY singleton when the size is 0.