### PR TITLE
override `OrderedPMap::containsKey` to provide better access (issue 120)

### DIFF
--- a/src/main/java/org/pcollections/OrderedPMap.java
+++ b/src/main/java/org/pcollections/OrderedPMap.java
@@ -66,6 +66,11 @@ public class OrderedPMap<K, V> extends AbstractUnmodifiableMap<K, V>
   }
 
   @Override
+  public boolean containsKey(Object key) {
+    return ids.containsKey(key);
+  }
+
+  @Override
   public OrderedPMap<K, V> plus(final K k, final V v) {
     Long id = ids.get(k);
     final PMap<K, Long> newIds;


### PR DESCRIPTION
`OrderedPMap` inherits `AbstractMap::containsKey` behaviour, which is O(N)